### PR TITLE
Md/pc search courses

### DIFF
--- a/javascript/package-lock.json
+++ b/javascript/package-lock.json
@@ -11026,6 +11026,14 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
+    "react-json-pretty": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/react-json-pretty/-/react-json-pretty-2.2.0.tgz",
+      "integrity": "sha512-3UMzlAXkJ4R8S4vmkRKtvJHTewG4/rn1Q18n0zqdu/ipZbUPLVZD+QwC7uVcD/IAY3s8iNVHlgR2dMzIUS0n1A==",
+      "requires": {
+        "prop-types": "^15.6.2"
+      }
+    },
     "react-json-view": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/react-json-view/-/react-json-view-1.19.1.tgz",

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -15,7 +15,8 @@
     "react-router-dom": "^5.2.0",
     "react-scripts": "3.4.3",
     "swr": "^0.3.2",
-    "uuid": "^8.3.0"
+    "uuid": "^8.3.0",
+    "react-json-pretty": "^2.2.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/javascript/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
+++ b/javascript/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
@@ -1,43 +1,67 @@
-import React from "react";
-import { Form,Button } from "react-bootstrap";
+import React, {useState} from "react";
+import { Form, Button } from "react-bootstrap";
+import fetch from "isomorphic-unfetch";
 
-const handleSubmit = (event) => {
-    event.preventDefault();
-    console.log("submit pressed");
-    debugger;
-};
+const BasicCourseSearchForm = ({ setCourseJSON }) => {
 
-const BasicCourseSearchForm = () => {
-  return (
-    <Form onSubmit={handleSubmit}>
-        <Form.Group controlId="BasicSearch.Quarter">
-            <Form.Label>Quarter</Form.Label>
-            <Form.Control as="select">
-            <option>W21</option>
-            <option>F20</option>
-            </Form.Control>
-        </Form.Group>
-        <Form.Group controlId="BasicSearch.Department">
-            <Form.Label>Department</Form.Label>
-            <Form.Control as="select">
-            <option>CMPSC</option>
-            <option>MATH</option>
-            </Form.Control>
-        </Form.Group>
-        <Form.Group controlId="BasicSearch.CourseLevel">
-            <Form.Label>Course Level</Form.Label>
-            <Form.Control as="select">
-            <option value="L">Undergrad-Lower Division</option>
-            <option value="S">Undergrad-Upper Division</option>
-            <option value="U">Undergrad-All</option>
-            <option value="G">Graduate</option>
-            </Form.Control>
-        </Form.Group>
-        <Button variant="primary" type="submit">
-        Submit
+    const [quarter, setQuarter] = useState("20211");
+    const [department, setDepartment] = useState("CMPSC");
+    const [level, setLevel] = useState("U");
+
+    const handleSubmit = async (event) => {
+        event.preventDefault();
+        console.log("submit pressed");
+
+        // send value of quarter, department and level to backend
+        const courseJSON =  JSON.stringify({course: "CS156"});
+    
+        //   (await fetch(`/api/public/basicsearch?qtr=${quarter}&dept={department}&level=${level}`)).json()
+        
+        setCourseJSON(courseJSON);
+    };
+
+    const handleQuarterOnChange = (event) => {
+        setQuarter(event.target.value);
+    };
+
+    const handleDepartmentOnChange = (event) => {
+        setDepartment(event.target.value);
+    };
+
+    const handleLevelOnChange = (event) => {
+        setLevel(event.target.value);
+    };
+
+    return (
+        <Form onSubmit={handleSubmit}>
+            <Form.Group controlId="BasicSearch.Quarter">
+                <Form.Label>Quarter</Form.Label>
+                <Form.Control as="select" onChange={handleQuarterOnChange} value={quarter}>
+                    <option value="20211">W21</option>
+                    <option value="20204">F20</option>
+                </Form.Control>
+            </Form.Group>
+            <Form.Group controlId="BasicSearch.Department">
+                <Form.Label>Department</Form.Label>
+                <Form.Control as="select" onChange={handleDepartmentOnChange} value={department}>
+                    <option>CMPSC</option>
+                    <option>MATH</option>
+                </Form.Control>
+            </Form.Group>
+            <Form.Group controlId="BasicSearch.CourseLevel">
+                <Form.Label>Course Level</Form.Label>
+                <Form.Control as="select" onChange={handleLevelOnChange} value={level}>
+                    <option value="L">Undergrad-Lower Division</option>
+                    <option value="S">Undergrad-Upper Division</option>
+                    <option value="U">Undergrad-All</option>
+                    <option value="G">Graduate</option>
+                </Form.Control>
+            </Form.Group>
+            <Button variant="primary" type="submit">
+                Submit
         </Button>
-    </Form>
-  );
+        </Form>
+    );
 };
 
 export default BasicCourseSearchForm;

--- a/javascript/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
+++ b/javascript/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
@@ -1,0 +1,37 @@
+import React from "react";
+import { Form,Button } from "react-bootstrap";
+
+const BasicCourseSearchForm = () => {
+  return (
+    <Form>
+        <Form.Group controlId="BasicSearch.Quarter">
+            <Form.Label>Quarter</Form.Label>
+            <Form.Control as="select">
+            <option>W21</option>
+            <option>F20</option>
+            </Form.Control>
+        </Form.Group>
+        <Form.Group controlId="BasicSearch.Department">
+            <Form.Label>Department</Form.Label>
+            <Form.Control as="select">
+            <option>CMPSC</option>
+            <option>MATH</option>
+            </Form.Control>
+        </Form.Group>
+        <Form.Group controlId="BasicSearch.CourseLevel">
+            <Form.Label>Course Level</Form.Label>
+            <Form.Control as="select">
+            <option value="L">Undergrad-Lower Division</option>
+            <option value="S">Undergrad-Upper Division</option>
+            <option value="U">Undergrad-All</option>
+            <option value="G">Graduate</option>
+            </Form.Control>
+        </Form.Group>
+        <Button variant="primary" type="submit">
+        Submit
+        </Button>
+    </Form>
+  );
+};
+
+export default BasicCourseSearchForm;

--- a/javascript/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
+++ b/javascript/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
@@ -1,9 +1,15 @@
 import React from "react";
 import { Form,Button } from "react-bootstrap";
 
+const handleSubmit = (event) => {
+    event.preventDefault();
+    console.log("submit pressed");
+    debugger;
+};
+
 const BasicCourseSearchForm = () => {
   return (
-    <Form>
+    <Form onSubmit={handleSubmit}>
         <Form.Group controlId="BasicSearch.Quarter">
             <Form.Label>Quarter</Form.Label>
             <Form.Control as="select">

--- a/javascript/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
+++ b/javascript/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
@@ -1,4 +1,4 @@
-import React, {useState} from "react";
+import React, { useState } from "react";
 import { Form, Button } from "react-bootstrap";
 import fetch from "isomorphic-unfetch";
 
@@ -8,16 +8,21 @@ const BasicCourseSearchForm = ({ setCourseJSON }) => {
     const [department, setDepartment] = useState("CMPSC");
     const [level, setLevel] = useState("U");
 
-    const handleSubmit = async (event) => {
+
+    const fetchJSON = async (event) => {
+        const url=`/api/public/basicsearch?qtr=${quarter}&dept=${department}&level=${level}`;
+        console.log(`fetching JSON, url=${url}`);
+        const courseJSON = (await fetch(url)).json()
+        console.log(`fetch returned, courseJSON=${courseJSON}`);
+        return courseJSON;
+    };
+
+    const handleSubmit = (event) => {
         event.preventDefault();
         console.log("submit pressed");
-
-        // send value of quarter, department and level to backend
-        const courseJSON =  JSON.stringify({course: "CS156"});
-    
-        //   (await fetch(`/api/public/basicsearch?qtr=${quarter}&dept={department}&level=${level}`)).json()
-        
-        setCourseJSON(courseJSON);
+        fetchJSON(event).then((courseJSON)=> {
+            setCourseJSON(courseJSON);
+        });
     };
 
     const handleQuarterOnChange = (event) => {

--- a/javascript/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
+++ b/javascript/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
@@ -8,11 +8,10 @@ const BasicCourseSearchForm = ({ setCourseJSON }) => {
     const [department, setDepartment] = useState("CMPSC");
     const [level, setLevel] = useState("U");
 
-
     const fetchJSON = async (event) => {
         const url=`/api/public/basicsearch?qtr=${quarter}&dept=${department}&level=${level}`;
         console.log(`fetching JSON, url=${url}`);
-        const courseJSON = (await fetch(url)).json()
+        const courseJSON = (await (await fetch(url)).json() )
         console.log(`fetch returned, courseJSON=${courseJSON}`);
         return courseJSON;
     };
@@ -41,7 +40,7 @@ const BasicCourseSearchForm = ({ setCourseJSON }) => {
         <Form onSubmit={handleSubmit}>
             <Form.Group controlId="BasicSearch.Quarter">
                 <Form.Label>Quarter</Form.Label>
-                <Form.Control as="select" onChange={handleQuarterOnChange} value={quarter}>
+                <Form.Control as="select" onChange={handleQuarterOnChange} value={quarter} data-testid="select-quarter" >
                     <option value="20211">W21</option>
                     <option value="20204">F20</option>
                 </Form.Control>

--- a/javascript/src/main/components/Utilities/JSONPrettyCard.js
+++ b/javascript/src/main/components/Utilities/JSONPrettyCard.js
@@ -2,7 +2,7 @@ import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { Card } from 'react-bootstrap'
 import JSONPretty from 'react-json-pretty';
-export default class JSONPrettyPanel extends Component {
+export default class JSONPrettyCard extends Component {
     constructor(props) {
         super(props);
     }
@@ -12,15 +12,13 @@ export default class JSONPrettyPanel extends Component {
                 <Card id={`JSONPrettyPanel-${this.props.expression}`}>
                     <Card.Body>
                         <Card.Title><code>{this.props.expression}</code></Card.Title>
-                        <Card.Text>
-                            <JSONPretty data={this.props.value} />
-                        </Card.Text>
+                        <JSONPretty data={this.props.value} />
                     </Card.Body>
                 </Card>
             </Fragment>
         );
     }
 }
-JSONPrettyPanel.propTypes = {
+JSONPrettyCard.propTypes = {
     expression: PropTypes.string.isRequired,
 };

--- a/javascript/src/main/components/Utilities/JSONPrettyPanel.js
+++ b/javascript/src/main/components/Utilities/JSONPrettyPanel.js
@@ -1,0 +1,26 @@
+import React, { Component, Fragment } from 'react';
+import PropTypes from 'prop-types';
+import { Card } from 'react-bootstrap'
+import JSONPretty from 'react-json-pretty';
+export default class JSONPrettyPanel extends Component {
+    constructor(props) {
+        super(props);
+    }
+    render() {
+        return (
+            <Fragment>
+                <Card id={`JSONPrettyPanel-${this.props.expression}`}>
+                    <Card.Body>
+                        <Card.Title><code>{this.props.expression}</code></Card.Title>
+                        <Card.Text>
+                            <JSONPretty data={this.props.value} />
+                        </Card.Text>
+                    </Card.Body>
+                </Card>
+            </Fragment>
+        );
+    }
+}
+JSONPrettyPanel.propTypes = {
+    expression: PropTypes.string.isRequired,
+};

--- a/javascript/src/main/pages/About/About.js
+++ b/javascript/src/main/pages/About/About.js
@@ -5,11 +5,12 @@ const About = () => {
     <Jumbotron>
       <h1>This is 127.0.0.1 (aka home)</h1>
       <div className="text-left">
-        <p>Welcome to UCSB Courses Search!</p>
         <p>
-          This app can hopefully help you understand how to use React with
-          Spring in order to create a functional web application. This app is
-          primarily built using the following:
+          This web application is a class project of
+          CMPSC 156 
+          at 
+          UC Santa Barbara. 
+          This app is primarily built using the following:
         </p>
         <ul>
           <li>

--- a/javascript/src/main/pages/Home/Home.js
+++ b/javascript/src/main/pages/Home/Home.js
@@ -2,6 +2,7 @@ import React from "react";
 import { Jumbotron } from "react-bootstrap";
 import {useAuth0} from "@auth0/auth0-react";
 import { Redirect } from "react-router-dom";
+import BasicCourseSearchForm from "../../components/BasicCourseSearch/BasicCourseSearchForm";
 
 const Home = () => {
     const { isAuthenticated } = useAuth0();
@@ -10,10 +11,7 @@ const Home = () => {
             <Jumbotron>
                 <div className="text-left">
                     <h5>Welcome to the UCSB Courses Search App!</h5>
-                    <p>A form to enter quarter, department and level, 
-                        together with a "Search" button will appear here
-                        in an upcoming release.
-                    </p>
+                    <BasicCourseSearchForm />
                 </div>
             </Jumbotron>
     );

--- a/javascript/src/main/pages/Home/Home.js
+++ b/javascript/src/main/pages/Home/Home.js
@@ -1,19 +1,28 @@
 import React from "react";
+import { useState } from "react";
 import { Jumbotron } from "react-bootstrap";
-import {useAuth0} from "@auth0/auth0-react";
+import { useAuth0 } from "@auth0/auth0-react";
 import { Redirect } from "react-router-dom";
 import BasicCourseSearchForm from "../../components/BasicCourseSearch/BasicCourseSearchForm";
+import JSONPrettyPanel from "../../components/Utilities/JSONPrettyPanel";
 
 const Home = () => {
     const { isAuthenticated } = useAuth0();
 
+    // const [courseJSON, setCourseJSON] = useState("");
+    // setCourseJSON('{"course" : "cs156"}');
+    const courseJSON = '{"course" : "cs156"}';
     return (
-            <Jumbotron>
-                <div className="text-left">
-                    <h5>Welcome to the UCSB Courses Search App!</h5>
-                    <BasicCourseSearchForm />
-                </div>
-            </Jumbotron>
+        <Jumbotron>
+            <div className="text-left">
+                <h5>Welcome to the UCSB Courses Search App!</h5>
+                <BasicCourseSearchForm />
+                <JSONPrettyPanel
+                    expression={"courseJSON"}
+                    value={courseJSON}
+                />
+            </div>
+        </Jumbotron>
     );
 };
 

--- a/javascript/src/main/pages/Home/Home.js
+++ b/javascript/src/main/pages/Home/Home.js
@@ -11,8 +11,6 @@ const Home = () => {
     // every function that starts with "use" is a hook
     // e.g. useState, useSWR, useAuth0
 
-    const { isAuthenticated } = useAuth0(); // a hook
-
     // courseJSON is the variable for the state
     // setCourseJSON is the setter
     // the parameter to useState is the initial value of the state

--- a/javascript/src/main/pages/Home/Home.js
+++ b/javascript/src/main/pages/Home/Home.js
@@ -7,16 +7,24 @@ import BasicCourseSearchForm from "../../components/BasicCourseSearch/BasicCours
 import JSONPrettyPanel from "../../components/Utilities/JSONPrettyPanel";
 
 const Home = () => {
-    const { isAuthenticated } = useAuth0();
+    
+    // every function that starts with "use" is a hook
+    // e.g. useState, useSWR, useAuth0
 
-    // const [courseJSON, setCourseJSON] = useState("");
-    // setCourseJSON('{"course" : "cs156"}');
-    const courseJSON = '{"course" : "cs156"}';
+    const { isAuthenticated } = useAuth0(); // a hook
+
+    // courseJSON is the variable for the state
+    // setCourseJSON is the setter
+    // the parameter to useState is the initial value of the state
+
+    const [courseJSON, setCourseJSON] = useState('{"course" : "cs148"}');
+
+    // const courseJSON = '{"course" : "cs156"}';
     return (
         <Jumbotron>
             <div className="text-left">
                 <h5>Welcome to the UCSB Courses Search App!</h5>
-                <BasicCourseSearchForm />
+                <BasicCourseSearchForm setCourseJSON={setCourseJSON} />
                 <JSONPrettyPanel
                     expression={"courseJSON"}
                     value={courseJSON}

--- a/javascript/src/main/pages/Home/Home.js
+++ b/javascript/src/main/pages/Home/Home.js
@@ -4,7 +4,7 @@ import { Jumbotron } from "react-bootstrap";
 import { useAuth0 } from "@auth0/auth0-react";
 import { Redirect } from "react-router-dom";
 import BasicCourseSearchForm from "../../components/BasicCourseSearch/BasicCourseSearchForm";
-import JSONPrettyPanel from "../../components/Utilities/JSONPrettyPanel";
+import JSONPrettyCard from "../../components/Utilities/JSONPrettyCard";
 
 const Home = () => {
     
@@ -25,7 +25,7 @@ const Home = () => {
             <div className="text-left">
                 <h5>Welcome to the UCSB Courses Search App!</h5>
                 <BasicCourseSearchForm setCourseJSON={setCourseJSON} />
-                <JSONPrettyPanel
+                <JSONPrettyCard
                     expression={"courseJSON"}
                     value={courseJSON}
                 />

--- a/javascript/src/test/components/BasicCourseSearch/BasicCourseSearchForm.test.js
+++ b/javascript/src/test/components/BasicCourseSearch/BasicCourseSearchForm.test.js
@@ -1,0 +1,72 @@
+import React from "react";
+import { render, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import fetch from "isomorphic-unfetch";
+jest.mock("isomorphic-unfetch");
+
+import BasicCourseSearchForm from "main/components/BasicCourseSearch/BasicCourseSearchForm";
+import JSONPretty from "react-json-pretty";
+
+describe("BasicCourseSearchForm tests", () => {
+
+    test("renders without crashing", () => {
+        render(<BasicCourseSearchForm />);
+    });
+
+    test("when I select a quarter, the state for quarter changes", () => {
+        const { getByTestId } = render(<BasicCourseSearchForm />);
+        const selectQuarter = getByTestId("select-quarter")
+        userEvent.selectOptions(selectQuarter, "20204");
+        expect(selectQuarter.value).toBe("20204");
+    });
+
+    test("when I select a department, the state for department changes", () => {
+        const { getByLabelText } = render(<BasicCourseSearchForm />);
+        const selectDepartment = getByLabelText("Department")
+        userEvent.selectOptions(selectDepartment, "MATH");
+        expect(selectDepartment.value).toBe("MATH");
+    });
+
+    test("when I select a level, the state for level changes", () => {
+        const { getByLabelText } = render(<BasicCourseSearchForm />);
+        const selectLevel = getByLabelText("Course Level")
+        userEvent.selectOptions(selectLevel, "G");
+        expect(selectLevel.value).toBe("G");
+    });
+
+    test("when I click submit, the right stuff happens", async () => {
+
+        const sampleReturnValue =  {
+            "level": "U",
+            "dept": "CMPSC",
+            "qtr": "20211"
+        };
+
+        fetch.mockResolvedValue({
+            json: async ()=>{
+                return sampleReturnValue;
+            } 
+        });
+
+        // Create a spy (aka jest function, magic function)
+        // The function doesn't have any implementation unless
+        // we specify one.  But it does keep track of whether 
+        // it was called, how many times it was called,
+        // and what it was passed.
+
+        const ourSpy = jest.fn();
+
+        const { getByText } = render(<BasicCourseSearchForm setCourseJSON={ourSpy}/>);
+        const submitButton = getByText("Submit");
+        userEvent.click(submitButton);
+
+        // we need to be careful not to assert this expectation
+        // until all of the async promises are resolved
+        await waitFor( () => expect(ourSpy).toHaveBeenCalledTimes(1) );
+
+        // assert that ourSpy was called with the right value
+        expect(ourSpy).toHaveBeenCalledWith(sampleReturnValue);
+    });
+
+
+});

--- a/src/main/java/edu/ucsb/courses/config/SecurityConfig.java
+++ b/src/main/java/edu/ucsb/courses/config/SecurityConfig.java
@@ -16,7 +16,7 @@ public class SecurityConfig extends ResourceServerConfigurerAdapter {
 
   @Override
   public void configure(HttpSecurity http) throws Exception {
-    http.authorizeRequests().mvcMatchers("/api/public").permitAll().mvcMatchers("/api/**")
+    http.authorizeRequests().mvcMatchers("/api/public/**").permitAll().mvcMatchers("/api/**")
         .authenticated().anyRequest().permitAll();
   }
 

--- a/src/main/java/edu/ucsb/courses/controllers/BasicSearchController.java
+++ b/src/main/java/edu/ucsb/courses/controllers/BasicSearchController.java
@@ -1,0 +1,41 @@
+package edu.ucsb.courses.controllers;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import javax.validation.Valid;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/public")
+public class BasicSearchController {
+    private final Logger logger = LoggerFactory.getLogger(BasicSearchController.class);
+
+    private ObjectMapper mapper = new ObjectMapper();
+
+    @GetMapping("/basicsearch")
+    public ResponseEntity<String> basicsearch(@RequestParam String qtr, @RequestParam String dept,
+            @RequestParam String level) throws JsonProcessingException {
+
+        Map<String,String> dummyDataMap = new HashMap<>();
+        dummyDataMap.put("qtr",qtr);
+        dummyDataMap.put("dept",dept);
+        dummyDataMap.put("level",level);
+        String dummyJSONData = mapper.writeValueAsString(dummyDataMap);
+
+        String body = dummyJSONData; // eventually replace with call to get real data
+
+        return ResponseEntity.ok().body(body);
+    }
+
+}


### PR DESCRIPTION
Closes #14 

In this PR, we add a basic course search form.   The form allows the user to enter qtr, dept, and level.  

We also add a backend endpoint `/api/public/basicsearch?qtr=20201&dept=CMPSC&level=A`, which for now, just echos back the parameters as JSON.

The courses search form sends the query parameters to the backend route and then echos the JSON that is returned.

Next step is to modify the backend route to return real results.