### PR TITLE
Pc add curriculum search service

### DIFF
--- a/secrets-heroku.properties.SAMPLE
+++ b/secrets-heroku.properties.SAMPLE
@@ -1,6 +1,7 @@
 app.namespace=https://NAME-OF-YOUR-APP.herokuapp.com
 app.admin.emails=phtcon@ucsb.edu
 app.member.hosted-domain=ucsb.edu
+app.ucsb.api.consumer_key=FILL-IT-IN
 
 auth0.domain=FILL-IT-IN
 auth0.clientId=FILL-IT-IN

--- a/secrets-localhost.properties.SAMPLE
+++ b/secrets-localhost.properties.SAMPLE
@@ -1,6 +1,7 @@
 app.namespace=https://NAME-OF-YOUR-APP.herokuapp.com
 app.admin.emails=phtcon@ucsb.edu
 app.member.hosted-domain=ucsb.edu
+app.ucsb.api.consumer_key=FILL-IT-IN
 
 auth0.domain=FILL-IT-IN
 auth0.clientId=FILL-IT-IN

--- a/src/main/java/edu/ucsb/courses/controllers/BasicSearchController.java
+++ b/src/main/java/edu/ucsb/courses/controllers/BasicSearchController.java
@@ -9,12 +9,15 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import edu.ucsb.courses.services.UCSBCurriculumService;
 
 @RestController
 @RequestMapping("/api/public")
@@ -23,17 +26,23 @@ public class BasicSearchController {
 
     private ObjectMapper mapper = new ObjectMapper();
 
+    @Autowired
+    UCSBCurriculumService ucsbCurriculumService;
+
     @GetMapping("/basicsearch")
-    public ResponseEntity<String> basicsearch(@RequestParam String qtr, @RequestParam String dept,
-            @RequestParam String level) throws JsonProcessingException {
+    public ResponseEntity<String> basicsearch(
+        @RequestParam String qtr, 
+        @RequestParam String dept,
+        @RequestParam String level) 
+        throws JsonProcessingException {
 
-        Map<String,String> dummyDataMap = new HashMap<>();
-        dummyDataMap.put("qtr",qtr);
-        dummyDataMap.put("dept",dept);
-        dummyDataMap.put("level",level);
-        String dummyJSONData = mapper.writeValueAsString(dummyDataMap);
+        // Map<String,String> dummyDataMap = new HashMap<>();
+        // dummyDataMap.put("qtr",qtr);
+        // dummyDataMap.put("dept",dept);
+        // dummyDataMap.put("level",level);
+        // String dummyJSONData = mapper.writeValueAsString(dummyDataMap);
 
-        String body = dummyJSONData; // eventually replace with call to get real data
+        String body = ucsbCurriculumService.getJSON(dept, qtr, level);
 
         return ResponseEntity.ok().body(body);
     }

--- a/src/main/java/edu/ucsb/courses/controllers/BasicSearchController.java
+++ b/src/main/java/edu/ucsb/courses/controllers/BasicSearchController.java
@@ -36,12 +36,6 @@ public class BasicSearchController {
         @RequestParam String level) 
         throws JsonProcessingException {
 
-        // Map<String,String> dummyDataMap = new HashMap<>();
-        // dummyDataMap.put("qtr",qtr);
-        // dummyDataMap.put("dept",dept);
-        // dummyDataMap.put("level",level);
-        // String dummyJSONData = mapper.writeValueAsString(dummyDataMap);
-
         String body = ucsbCurriculumService.getJSON(dept, qtr, level);
 
         return ResponseEntity.ok().body(body);

--- a/src/main/java/edu/ucsb/courses/controllers/BasicSearchController.java
+++ b/src/main/java/edu/ucsb/courses/controllers/BasicSearchController.java
@@ -29,7 +29,7 @@ public class BasicSearchController {
     @Autowired
     UCSBCurriculumService ucsbCurriculumService;
 
-    @GetMapping("/basicsearch")
+    @GetMapping(value = "/basicsearch", produces = "application/json")
     public ResponseEntity<String> basicsearch(
         @RequestParam String qtr, 
         @RequestParam String dept,

--- a/src/main/java/edu/ucsb/courses/services/UCSBCurriculumService.java
+++ b/src/main/java/edu/ucsb/courses/services/UCSBCurriculumService.java
@@ -23,15 +23,12 @@ public class UCSBCurriculumService  {
 
     private Logger logger = LoggerFactory.getLogger(UCSBCurriculumService.class);
 
+    @Value("${app.ucsb.api.consumer_key}")
     private String apiKey;
 
-    public UCSBCurriculumService(@Value("${app.ucsb.api.consumer_key}") String apiKey) {
-        this.apiKey = apiKey;
-    }
+    private RestTemplate restTemplate = new RestTemplate();
 
     public String getJSON(String subjectArea, String quarter, String courseLevel) {
-
-        RestTemplate restTemplate = new RestTemplate();
 
         HttpHeaders headers = new HttpHeaders();
         headers.setAccept(Arrays.asList(MediaType.APPLICATION_JSON));

--- a/src/main/java/edu/ucsb/courses/services/UCSBCurriculumService.java
+++ b/src/main/java/edu/ucsb/courses/services/UCSBCurriculumService.java
@@ -1,0 +1,75 @@
+package edu.ucsb.courses.services;
+
+import java.util.Arrays;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * Service object that wraps the UCSB Academic Curriculum API
+ */
+@Service
+public class UCSBCurriculumService  {
+
+    private Logger logger = LoggerFactory.getLogger(UCSBCurriculumService.class);
+
+    private String apiKey;
+
+    public UCSBCurriculumService(@Value("${app.ucsb.api.consumer_key}") String apiKey) {
+        this.apiKey = apiKey;
+    }
+
+    public String getJSON(String subjectArea, String quarter, String courseLevel) {
+
+        RestTemplate restTemplate = new RestTemplate();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setAccept(Arrays.asList(MediaType.APPLICATION_JSON));
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.set("ucsb-api-version", "1.0");
+        headers.set("ucsb-api-key", this.apiKey);
+
+        HttpEntity<String> entity = new HttpEntity<>("body", headers);
+
+        String uri = "https://api.ucsb.edu/academics/curriculums/v1/classes/search";
+        String params = String.format(
+                "?quarter=%s&subjectCode=%s&objLevelCode=%s&pageNumber=%d&pageSize=%d&includeClassSections=%s", quarter,
+                subjectArea, courseLevel, 1, 100, "true");
+        String url = uri + params;
+
+        if (courseLevel.equals("A")) {
+            params = String.format(
+                    "?quarter=%s&subjectCode=%s&pageNumber=%d&pageSize=%d&includeClassSections=%s",
+                    quarter, subjectArea, 1, 100, "true");
+            url = uri + params;
+        }
+
+        logger.info("url=" + url);
+
+        String retVal = "";
+        MediaType contentType=null;
+        HttpStatus statusCode=null;
+        try {
+            ResponseEntity<String> re = restTemplate.exchange(url, HttpMethod.GET, entity, String.class);
+            contentType = re.getHeaders().getContentType();
+            statusCode = re.getStatusCode();
+            retVal = re.getBody();
+        } catch (HttpClientErrorException e) {
+            retVal = "{\"error\": \"401: Unauthorized\"}";
+        }
+        logger.info("json: {} contentType: {} statusCode: {}",retVal,contentType,statusCode);
+        return retVal;
+    }
+
+    
+}

--- a/src/test/java/edu/ucsb/courses/controllers/BasicSearchControllerTest.java
+++ b/src/test/java/edu/ucsb/courses/controllers/BasicSearchControllerTest.java
@@ -1,0 +1,53 @@
+package edu.ucsb.courses.controllers;
+
+import edu.ucsb.courses.config.SecurityConfig;
+import edu.ucsb.courses.services.UCSBCurriculumService;
+
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+// @Import(SecurityConfig.class) applies the security rules 
+// so that /api/public/** endpoints don't require authentication.
+// Otherwise you may get authorization errors when running the test
+
+@WebMvcTest(value = BasicSearchController.class)
+@Import(SecurityConfig.class)
+public class BasicSearchControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private UCSBCurriculumService ucsbCurriculumService;
+
+    @Test
+    public void test_basicSearch() throws Exception {
+
+        String expectedResult = "{expectedJSONResult}";
+        String urlTemplate = "/api/public/basicsearch?qtr=%s&dept=%s&level=%s";
+        String url = String.format(urlTemplate, "20204", "CMPSC", "L");
+        when(ucsbCurriculumService.getJSON(any(String.class), any(String.class), any(String.class)))
+                .thenReturn(expectedResult);
+
+        MvcResult response = mockMvc.perform(get(url).contentType("application/json")).andExpect(status().isOk())
+                .andReturn();
+        String responseString = response.getResponse().getContentAsString();
+
+        assertEquals(expectedResult, responseString);
+    }
+
+}

--- a/src/test/java/edu/ucsb/courses/services/UCSBCurriculumServiceTest.java
+++ b/src/test/java/edu/ucsb/courses/services/UCSBCurriculumServiceTest.java
@@ -1,0 +1,46 @@
+package edu.ucsb.courses.services;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import edu.ucsb.courses.models.GoogleUserProfile;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.web.client.RestTemplate;
+
+
+@ExtendWith(SpringExtension.class)
+public class UCSBCurriculumServiceTest {
+
+    @Mock
+    private RestTemplate restTemplate;
+  
+    @InjectMocks
+    private UCSBCurriculumService ucs;
+  
+    @Test
+    public void test_getJSON() throws Exception {
+        String expectedResult = "{expectedResult}";
+
+      when(restTemplate.exchange(any(String.class), eq(HttpMethod.GET), any(HttpEntity.class),
+          eq(String.class)))
+              .thenReturn(new ResponseEntity<String>(expectedResult, HttpStatus.OK));
+  
+      String subjectArea = "CMPSC";
+      String quarter="20201";
+      String level="L";
+
+      String result = ucs.getJSON(subjectArea,quarter,level);
+
+      assertEquals(expectedResult,result);
+    }
+
+}

--- a/src/test/java/edu/ucsb/courses/services/UCSBCurriculumServiceTest.java
+++ b/src/test/java/edu/ucsb/courses/services/UCSBCurriculumServiceTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
-import edu.ucsb.courses.models.GoogleUserProfile;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;

--- a/src/test/java/edu/ucsb/courses/services/UCSBCurriculumServiceTest.java
+++ b/src/test/java/edu/ucsb/courses/services/UCSBCurriculumServiceTest.java
@@ -14,32 +14,53 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.web.client.RestTemplate;
-
+import org.springframework.web.client.HttpClientErrorException;
 
 @ExtendWith(SpringExtension.class)
 public class UCSBCurriculumServiceTest {
 
     @Mock
     private RestTemplate restTemplate;
-  
+
     @InjectMocks
     private UCSBCurriculumService ucs;
-  
+
     @Test
-    public void test_getJSON() throws Exception {
+    public void test_getJSON_success() throws Exception {
         String expectedResult = "{expectedResult}";
 
-      when(restTemplate.exchange(any(String.class), eq(HttpMethod.GET), any(HttpEntity.class),
-          eq(String.class)))
-              .thenReturn(new ResponseEntity<String>(expectedResult, HttpStatus.OK));
-  
-      String subjectArea = "CMPSC";
-      String quarter="20201";
-      String level="L";
+        when(restTemplate.exchange(any(String.class), eq(HttpMethod.GET), any(HttpEntity.class), eq(String.class)))
+                .thenReturn(new ResponseEntity<String>(expectedResult, HttpStatus.OK));
 
-      String result = ucs.getJSON(subjectArea,quarter,level);
+        String subjectArea = "CMPSC";
+        String quarter = "20201";
+        String level = "L";
 
-      assertEquals(expectedResult,result);
+        String result = ucs.getJSON(subjectArea, quarter, level);
+
+        assertEquals(expectedResult, result);
+
+        level = "A";
+        result = ucs.getJSON(subjectArea, quarter, level);
+
+        assertEquals(expectedResult, result);
+    }
+
+    @Test
+    public void test_getJSON_exception() throws Exception {
+
+        String expectedResult = "{\"error\": \"401: Unauthorized\"}";
+
+        when(restTemplate.exchange(any(String.class), eq(HttpMethod.GET), any(HttpEntity.class), eq(String.class)))
+                .thenThrow(HttpClientErrorException.class);
+
+        String subjectArea = "CMPSC";
+        String quarter = "20201";
+        String level = "L";
+
+        String result = ucs.getJSON(subjectArea, quarter, level);
+
+        assertEquals(expectedResult, result);
     }
 
 }


### PR DESCRIPTION
In this PR, we add a service object that talks to the UCSB Curriculum API.   This service object will get course information for a given quarter, department, and level, in JSON format.

We also modify the BasicSearchController to use this object to retrieve the course information.

Next steps will be to replace the JSON view with a nicer view of the course info; this would involve writing a React Component.