### PR TITLE
Pc authorized routes

### DIFF
--- a/javascript/src/main/App.js
+++ b/javascript/src/main/App.js
@@ -2,6 +2,7 @@ import React from "react";
 import "main/App.css";
 import Loading from "main/components/Loading/Loading";
 import AppNavbar from "main/components/Nav/AppNavbar";
+import AuthorizedRoute from "main/components/Nav/AuthorizedRoute";
 import { useAuth0 } from "@auth0/auth0-react";
 import { Container } from "react-bootstrap";
 import { Route, Switch } from "react-router-dom";
@@ -33,9 +34,7 @@ function App() {
         <Switch>
           <Route path="/" exact component={Home} />
           <PrivateRoute path="/profile" component={Profile} />
-          { isAdmin &&
-            <PrivateRoute path="/admin" component={Admin} />
-          }
+          <AuthorizedRoute path="/admin" component={Admin} authorizedRoles={["admin"]}  />
           <Route path="/about" component={About} />
         </Switch>
       </Container>

--- a/javascript/src/main/components/Auth/README.md
+++ b/javascript/src/main/components/Auth/README.md
@@ -1,0 +1,36 @@
+This directory `javascript/src/main/components/Auth` is excluded from test coverage as of 11/16/2020.  
+
+# Why:
+
+* Most of this is Auth0 boilerplate code.
+* It was difficult to see how to test this without internal
+  knowledge of Auth0 code; it seemed to require mocking
+  of sub-dependencies that are difficult to determine.
+
+If and when test coverage for these components is added,
+the comments in this file should be removed.
+
+In the meantime, try to keep the code in these components
+minimal, and restricted only to Auth0 boilerplate that 
+is less critical to test.
+
+# How
+
+This exclusion is in `package.json` with code like this:
+
+```yml
+...
+  "jest": {
+    "resetMocks": true,
+    "collectCoverageFrom": [
+      "src/**/*.{js,jsx,ts,tsx}",
+      "!src/serviceWorker.js",
+      "!src/setupTests.js",
+      "!src/main/components/Auth/*",
+      "!src/index.js"
+    ],
+    ...
+  }
+...
+```
+

--- a/javascript/src/main/components/Nav/AuthorizedRoute.js
+++ b/javascript/src/main/components/Nav/AuthorizedRoute.js
@@ -1,0 +1,24 @@
+import React from "react";
+import { Route } from "react-router-dom";
+import {useAuth0} from "@auth0/auth0-react";
+import useSWR from "swr";
+import {fetchWithToken} from "main/utils/fetch";
+import Loading from "main/components/Loading/Loading";
+
+const AuthorizedRoute = ({component, authorizedRoles, ...args}) => {
+  const { isLoading, getAccessTokenSilently: getToken } = useAuth0();
+  const { data: roleInfo } = useSWR(
+    ["/api/myRole", getToken],
+    fetchWithToken
+  );
+  const isAuthorized = roleInfo && authorizedRoles.includes(roleInfo.role.toLowerCase());
+
+  if (isLoading) {
+    return <Loading />;
+  }
+  return (
+    <Route component={isAuthorized ? component : null} {...args} />
+  );
+}
+
+export default AuthorizedRoute; 

--- a/javascript/src/test/components/Nav/AuthorizedRoute.test.js
+++ b/javascript/src/test/components/Nav/AuthorizedRoute.test.js
@@ -1,0 +1,53 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import AuthorizedRoute from "main/components/Nav/AuthorizedRoute";
+import { createMemoryHistory } from "history";
+import { Router } from "react-router-dom";
+import { useAuth0 } from "@auth0/auth0-react";
+jest.mock("@auth0/auth0-react");
+import useSWR from "swr";
+jest.mock("swr");
+
+describe("Authorized Route tests", () => {
+  const component = () => {
+    return (<div>Hello</div>);
+  }
+
+  beforeEach(() => {
+    useAuth0.mockReturnValue({
+      isLoading: false,
+      getAccessTokenSilently: jest.fn(),
+    });
+    useSWR.mockReturnValue({
+      data: {
+        role: "guest"
+      }
+    });
+  });
+
+  test("if data not yet retrieved, render loading", () => {
+    useAuth0.mockReturnValue({
+      isLoading: true
+    });
+    const {getByAltText} = render(
+    <Router history={createMemoryHistory()}>
+      <AuthorizedRoute component={component} authorizedRoles={[]}/>
+    </Router>);
+    expect(getByAltText("Loading")).toBeInTheDocument();
+  });
+  test("if role doesn't match authorized role, component should not render", () => {
+    const {queryByText} = render(
+    <Router history={createMemoryHistory()}>
+      <AuthorizedRoute component={component} authorizedRoles={["admin"]} />
+    </Router>);
+    expect(queryByText("Hello")).toBe(null);
+  });
+
+  test("if condition is true, component should", () => {
+    const {getByText} = render(
+    <Router history={createMemoryHistory()}>
+      <AuthorizedRoute component={component} authorizedRoles={["guest"]} />
+    </Router>);
+    expect(getByText("Hello")).toBeInTheDocument();
+  });
+});

--- a/javascript/src/test/components/Nav/AuthorizedRoute.test.js
+++ b/javascript/src/test/components/Nav/AuthorizedRoute.test.js
@@ -43,7 +43,7 @@ describe("Authorized Route tests", () => {
     expect(queryByText("Hello")).toBe(null);
   });
 
-  test("if condition is true, component should", () => {
+  test("if role is an authorized role, component should render", () => {
     const {getByText} = render(
     <Router history={createMemoryHistory()}>
       <AuthorizedRoute component={component} authorizedRoles={["guest"]} />


### PR DESCRIPTION
In this commit we introduce a new AuthorizedRoute component,
identical to one introduced into proj-mapache-search in
ucsb-cs156-f20/proj-mapache-search@80fb48c by @scottpchow23

The new pattern is this:

* `Route` does not require you to be logged in
* `PrivateRoute` requires you to be logged in
* `AuthorizedRoute` requires you to be logged in with a specific role

We also add a `README.md` to Auth0 component directory …
to document that Auth0 is excluded from tests, and why.