### PR TITLE
Fix Codecov badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ucsb-courses-search
 
-[![codecov](https://codecov.io/gh/ucsb-cs156-f20/ucsb-courses-search/branch/main/graph/badge.svg)](https://codecov.io/gh/ucsb-cs156-f20/ucsb-courses-search)
+[![codecov](https://codecov.io/gh/ucsb-cs156-f20/proj-ucsb-courses-search/branch/main/graph/badge.svg)](https://codecov.io/gh/ucsb-cs156-f20/proj-ucsb-courses-search)
 
 ## Purpose
 


### PR DESCRIPTION
In this PR, we fix the link to the codecov badge in the README.md so that it goes to the correct url.