### PR TITLE
Staff f20 refactor basic course search

### DIFF
--- a/javascript/src/main/App.js
+++ b/javascript/src/main/App.js
@@ -9,6 +9,7 @@ import { Route, Switch } from "react-router-dom";
 import AppFooter from "main/components/Footer/AppFooter";
 import About from "main/pages/About/About";
 import Home from "main/pages/Home/Home";
+import Basic from "main/pages/History/Basic";
 import Profile from "main/pages/Profile/Profile";
 import PrivateRoute from "main/components/Auth/PrivateRoute";
 import Admin from "main/pages/Admin/Admin";
@@ -33,6 +34,7 @@ function App() {
       <Container className="flex-grow-1 mt-5">
         <Switch>
           <Route path="/" exact component={Home} />
+          <Route path="/history/basic" exact component={Basic} />
           <PrivateRoute path="/profile" component={Profile} />
           <AuthorizedRoute path="/admin" component={Admin} authorizedRoles={["admin"]}  />
           <Route path="/about" component={About} />

--- a/javascript/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
+++ b/javascript/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
@@ -8,14 +8,6 @@ const BasicCourseSearchForm = ({ setCourseJSON, fetchJSON }) => {
     const [department, setDepartment] = useState("CMPSC");
     const [level, setLevel] = useState("U");
 
-    // const fetchJSON = async (event) => {
-    //     const url=`/api/public/basicsearch?qtr=${quarter}&dept=${department}&level=${level}`;
-    //     console.log(`fetching JSON, url=${url}`);
-    //     const courseJSON = (await (await fetch(url)).json() )
-    //     console.log(`fetch returned, courseJSON=${courseJSON}`);
-    //     return courseJSON;
-    // };
-
     const handleSubmit = (event) => {
         event.preventDefault();
         console.log("submit pressed");

--- a/javascript/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
+++ b/javascript/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
@@ -2,24 +2,24 @@ import React, { useState } from "react";
 import { Form, Button } from "react-bootstrap";
 import fetch from "isomorphic-unfetch";
 
-const BasicCourseSearchForm = ({ setCourseJSON }) => {
+const BasicCourseSearchForm = ({ setCourseJSON, fetchJSON }) => {
 
     const [quarter, setQuarter] = useState("20211");
     const [department, setDepartment] = useState("CMPSC");
     const [level, setLevel] = useState("U");
 
-    const fetchJSON = async (event) => {
-        const url=`/api/public/basicsearch?qtr=${quarter}&dept=${department}&level=${level}`;
-        console.log(`fetching JSON, url=${url}`);
-        const courseJSON = (await (await fetch(url)).json() )
-        console.log(`fetch returned, courseJSON=${courseJSON}`);
-        return courseJSON;
-    };
+    // const fetchJSON = async (event) => {
+    //     const url=`/api/public/basicsearch?qtr=${quarter}&dept=${department}&level=${level}`;
+    //     console.log(`fetching JSON, url=${url}`);
+    //     const courseJSON = (await (await fetch(url)).json() )
+    //     console.log(`fetch returned, courseJSON=${courseJSON}`);
+    //     return courseJSON;
+    // };
 
     const handleSubmit = (event) => {
         event.preventDefault();
         console.log("submit pressed");
-        fetchJSON(event).then((courseJSON)=> {
+        fetchJSON(event, {quarter, department, level}).then((courseJSON)=> {
             setCourseJSON(courseJSON);
         });
     };

--- a/javascript/src/main/components/Nav/AppNavbar.js
+++ b/javascript/src/main/components/Nav/AppNavbar.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Nav, Navbar } from "react-bootstrap";
+import { Nav, Navbar, NavDropdown } from "react-bootstrap";
 import { LinkContainer } from "react-router-bootstrap";
 import AuthNav from "main/components/Nav/AuthNav";
 import ProfileNav from "main/components/Nav/ProfileNav";
@@ -22,6 +22,9 @@ function AppNavbar() {
         <Navbar.Brand data-testid="brand">UCSB Courses Search</Navbar.Brand>
       </LinkContainer>
       <Nav>
+        <NavDropdown title="Course History">
+            <NavDropdown.Item href="/history/basic">Basic Search</NavDropdown.Item>
+        </NavDropdown>
         { isAdmin &&
           (<LinkContainer to={"/admin"}>
             <Nav.Link>Admin</Nav.Link>

--- a/javascript/src/main/pages/History/Basic.js
+++ b/javascript/src/main/pages/History/Basic.js
@@ -1,0 +1,36 @@
+import React from "react";
+import { useState } from "react";
+import { Jumbotron } from "react-bootstrap";
+import { useAuth0 } from "@auth0/auth0-react";
+import { Redirect } from "react-router-dom";
+import BasicCourseSearchForm from "../../components/BasicCourseSearch/BasicCourseSearchForm";
+import JSONPrettyCard from "../../components/Utilities/JSONPrettyCard";
+import { fetchBasicCourseJSON } from "main/services/courseSearches";
+
+const Basic = () => {
+
+    // every function that starts with "use" is a hook
+    // e.g. useState, useSWR, useAuth0
+
+    // courseJSON is the variable for the state
+    // setCourseJSON is the setter
+    // the parameter to useState is the initial value of the state
+
+    const [courseJSON, setCourseJSON] = useState('{"course" : "cs148"}');
+
+    // const courseJSON = '{"course" : "cs156"}';
+    return (
+        <Jumbotron>
+            <div className="text-left">
+                <h5>Search Archived Course Data from MongoDB</h5>
+                <BasicCourseSearchForm setCourseJSON={setCourseJSON} fetchJSON={fetchBasicCourseJSON} />
+                <JSONPrettyCard
+                    expression={"courseJSON"}
+                    value={courseJSON}
+                />
+            </div>
+        </Jumbotron>
+    );
+};
+
+export default Basic;

--- a/javascript/src/main/pages/Home/Home.js
+++ b/javascript/src/main/pages/Home/Home.js
@@ -5,9 +5,10 @@ import { useAuth0 } from "@auth0/auth0-react";
 import { Redirect } from "react-router-dom";
 import BasicCourseSearchForm from "../../components/BasicCourseSearch/BasicCourseSearchForm";
 import JSONPrettyCard from "../../components/Utilities/JSONPrettyCard";
+import { fetchBasicCourseJSON } from "main/services/courseSearches";
 
 const Home = () => {
-    
+
     // every function that starts with "use" is a hook
     // e.g. useState, useSWR, useAuth0
 
@@ -22,7 +23,7 @@ const Home = () => {
         <Jumbotron>
             <div className="text-left">
                 <h5>Welcome to the UCSB Courses Search App!</h5>
-                <BasicCourseSearchForm setCourseJSON={setCourseJSON} />
+                <BasicCourseSearchForm setCourseJSON={setCourseJSON} fetchJSON={fetchBasicCourseJSON} />
                 <JSONPrettyCard
                     expression={"courseJSON"}
                     value={courseJSON}

--- a/javascript/src/main/services/courseSearches.js
+++ b/javascript/src/main/services/courseSearches.js
@@ -1,0 +1,12 @@
+import fetch from "isomorphic-unfetch";
+
+ const fetchBasicCourseJSON = async (event, fields) => {
+    const url = `/api/public/basicsearch?qtr=${fields.quarter}&dept=${fields.department}&level=${fields.level}`;
+    console.log(`fetching JSON, url=${url}`);
+    const courseJSON = (await (await fetch(url)).json())
+    console.log(`fetch returned, courseJSON=${courseJSON}`);
+    return courseJSON;
+};
+
+export { fetchBasicCourseJSON };
+    

--- a/javascript/src/test/components/BasicCourseSearch/BasicCourseSearchForm.test.js
+++ b/javascript/src/test/components/BasicCourseSearch/BasicCourseSearchForm.test.js
@@ -36,37 +36,51 @@ describe("BasicCourseSearchForm tests", () => {
 
     test("when I click submit, the right stuff happens", async () => {
 
-        const sampleReturnValue =  {
-            "level": "U",
-            "dept": "CMPSC",
-            "qtr": "20211"
+        const sampleReturnValue = {
+            "sampleKey": "sampleValue"
         };
 
-        fetch.mockResolvedValue({
-            json: async ()=>{
-                return sampleReturnValue;
-            } 
-        });
-
-        // Create a spy (aka jest function, magic function)
+        // Create spy functions (aka jest function, magic function)
         // The function doesn't have any implementation unless
         // we specify one.  But it does keep track of whether 
         // it was called, how many times it was called,
         // and what it was passed.
 
-        const ourSpy = jest.fn();
+        const setCourseJSONSpy = jest.fn();
+        const fetchJSONSpy = jest.fn();
 
-        const { getByText } = render(<BasicCourseSearchForm setCourseJSON={ourSpy}/>);
+        fetchJSONSpy.mockResolvedValue(sampleReturnValue);
+
+        const { getByText, getByLabelText } = render(
+            <BasicCourseSearchForm setCourseJSON={setCourseJSONSpy} fetchJSON={fetchJSONSpy} />
+        );
+
+        const expectedFields = {
+            quarter: "20204",
+            department: "MATH",
+            level: "G"
+        };
+
+        const selectQuarter = getByLabelText("Quarter")
+        userEvent.selectOptions(selectQuarter, "20204");
+        const selectDepartment = getByLabelText("Department")
+        userEvent.selectOptions(selectDepartment, "MATH");
+        const selectLevel = getByLabelText("Course Level")
+        userEvent.selectOptions(selectLevel, "G");
+
         const submitButton = getByText("Submit");
         userEvent.click(submitButton);
 
         // we need to be careful not to assert this expectation
         // until all of the async promises are resolved
-        await waitFor( () => expect(ourSpy).toHaveBeenCalledTimes(1) );
+        await waitFor(() => expect(setCourseJSONSpy).toHaveBeenCalledTimes(1));
+        await waitFor(() => expect(fetchJSONSpy).toHaveBeenCalledTimes(1));
 
         // assert that ourSpy was called with the right value
-        expect(ourSpy).toHaveBeenCalledWith(sampleReturnValue);
+        expect(setCourseJSONSpy).toHaveBeenCalledWith(sampleReturnValue);
+        expect(fetchJSONSpy).toHaveBeenCalledWith(expect.any(Object), expectedFields);
+
     });
 
-
 });
+

--- a/javascript/src/test/pages/History/Basic.test.js
+++ b/javascript/src/test/pages/History/Basic.test.js
@@ -1,9 +1,9 @@
 import React from "react";
 import { render } from "@testing-library/react";
-import Home from "main/pages/Home/Home";
+import Basic from "main/pages/History/Basic";
 
-describe("Home tests", () => {
+describe("History Basic Course Search page tests", () => {
   test("renders without crashing", () => {
-    render(<Home/>);
+    render(<Basic/>);
   });
 });

--- a/javascript/src/test/pages/Home/Home.test.js
+++ b/javascript/src/test/pages/Home/Home.test.js
@@ -1,6 +1,10 @@
 import React from "react";
-import { render } from "@testing-library/react";
+import { render, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import Home from "main/pages/Home/Home";
+
+// import { fetchBasicCourseJSON } from "main/services/courseSearches";
+// jest.mock("main/services/courseSearches");
 
 describe("Home tests", () => {
   test("renders without crashing", () => {

--- a/javascript/src/test/services/courseSearches.test.js
+++ b/javascript/src/test/services/courseSearches.test.js
@@ -1,0 +1,34 @@
+import React from "react";
+import { render, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import Home from "main/pages/Home/Home";
+import fetch from "isomorphic-unfetch";
+import { fetchBasicCourseJSON } from "main/services/courseSearches";
+
+jest.mock("isomorphic-unfetch");
+
+describe("courseSearches tests",  () => {
+  test("fetchBasicCourseJSON", async () => {
+    
+    const sampleReturnValue = {
+        "sampleKey": "sampleValue"
+    };
+
+    fetch.mockResolvedValue({
+        status: 200,
+        json: () => {
+          return sampleReturnValue;
+        },
+      });
+
+    const expectedFields = {
+        quarter: "20204",
+        department: "MATH",
+        level: "G"
+    };
+
+    const result = fetchBasicCourseJSON({},expectedFields);
+    expect(await result).toBe(sampleReturnValue);
+
+  });
+});


### PR DESCRIPTION
In this PR, we 
* Refactor the BasicCourseSearchForm component to decouple the logic that fetches from the backend into a service
* Add a new top level navigation item `Course History` that will provide a way to do searches on historical data (not the live data from the API)
* Add a Basic Search on that menu as a proof of concept, reusing the `BasicCourseSearchForm`.  For now, it actually does NOT use the MongoDB archived course data; fixing it so that it does is a separate story.
