### PR TITLE
jv - add course occupancy by department statistics page

### DIFF
--- a/javascript/src/main/App.js
+++ b/javascript/src/main/App.js
@@ -12,6 +12,7 @@ import Statistics from "main/pages/Statistics/Statistics";
 import DivisionOccupancy from "main/pages/Statistics/DivisionOccupancy"
 import ClassSize from "main/pages/Statistics/ClassSize";
 import Schedule from "main/pages/Schedule/Schedule";
+import CourseOccupancy from "main/pages/Statistics/CourseOccupancy";
 import Home from "main/pages/Home/Home";
 import Basic from "main/pages/History/Basic";
 import Ge from "main/pages/History/Ge";
@@ -45,6 +46,7 @@ function App() {
           <Route path="/statistics" exact component={Statistics} />
           <Route path="/statistics/courseOccupancyByDivision" exact component={DivisionOccupancy} />
           <Route path="/statistics/classSize" exact component={ClassSize} />
+          <Route path="/statistics/courseOccupancy" exact component={CourseOccupancy} />
           <Route path="/history/ge" exact component={Ge} />
           <PrivateRoute path="/profile" component={Profile} />
           <AuthorizedRoute path="/admin" component={Admin} authorizedRoles={["admin"]}  />

--- a/javascript/src/main/components/Nav/AppNavbar.js
+++ b/javascript/src/main/components/Nav/AppNavbar.js
@@ -41,7 +41,7 @@ function AppNavbar() {
           <NavDropdown.Item as={Link} to="/statistics">
             Full Classes by Department
           </NavDropdown.Item>
-          <NavDropdown.Item as={Link} to="/statistics">
+          <NavDropdown.Item as={Link} to="/statistics/courseOccupancy">
             Course Occupancy by Department
           </NavDropdown.Item>
           <NavDropdown.Item as={Link} to="/statistics/courseOccupancyByDivision">

--- a/javascript/src/main/components/Statistics/CourseOccupancyForm.js
+++ b/javascript/src/main/components/Statistics/CourseOccupancyForm.js
@@ -1,5 +1,7 @@
 import React, { useState } from "react";
 import { Form, Button } from "react-bootstrap";
+import DepartmentFormSelect from "main/components/Statistics/DepartmentFormSelect";
+import QuarterFormSelect from "main/components/Statistics/QuarterFormSelect";
 
 const CourseOccupancyForm = ({ setOccupancyJson, fetchJSON }) => {
 
@@ -18,40 +20,19 @@ const CourseOccupancyForm = ({ setOccupancyJson, fetchJSON }) => {
 
     };
 
-    const handleStartQuarterOnChange = (event) => {
-        setStartQuarter(event.target.value);
-    };
-
-    const handleEndQuarterOnChange = (event) => {
-        setEndQuarter(event.target.value);
-    };
-
-    const handleDepartmentOnChange = (event) => {
-        setDepartment(event.target.value);
-    };
-
     return (
         <Form onSubmit={handleSubmit}>
             <Form.Group controlId="CourseOccupancy.StartQuarter">
                 <Form.Label>Start Quarter</Form.Label>
-                <Form.Control as="select" onChange={handleStartQuarterOnChange} value={startQuarter} data-testid="select-start-quarter" >
-                    <option value="20211">W21</option>
-                    <option value="20204">F20</option>
-                </Form.Control>
+                <QuarterFormSelect handleSelect={setStartQuarter} initialQuarter={4} initialYear={2020} testId={"select-start"}/>
             </Form.Group>
             <Form.Group controlId="CourseOccupancy.EndQuarter">
                 <Form.Label>End Quarter</Form.Label>
-                <Form.Control as="select" onChange={handleEndQuarterOnChange} value={endQuarter} data-testid="select-end-quarter" >
-                    <option value="20211">W21</option>
-                    <option value="20204">F20</option>
-                </Form.Control>
+                <QuarterFormSelect handleSelect={setEndQuarter} initialQuarter={1} initialYear={2021} testId={"select-end"}/>
             </Form.Group>
             <Form.Group controlId="CourseOccupancy.Department">
                 <Form.Label>Department</Form.Label>
-                <Form.Control as="select" onChange={handleDepartmentOnChange} value={department} data-testid="select-department">
-                    <option value="CMPSC">CMPSC</option>
-                    <option value="MATH ">MATH</option>
-                </Form.Control>
+                <DepartmentFormSelect handleSelect={setDepartment} value={department}/>
             </Form.Group>
             <Button variant="primary" type="submit">
                 Submit

--- a/javascript/src/main/components/Statistics/CourseOccupancyForm.js
+++ b/javascript/src/main/components/Statistics/CourseOccupancyForm.js
@@ -1,0 +1,63 @@
+import React, { useState } from "react";
+import { Form, Button } from "react-bootstrap";
+
+const CourseOccupancyForm = ({ setOccupancyJson, fetchJSON }) => {
+
+    const [startQuarter, setStartQuarter] = useState("20204");
+    const [endQuarter, setEndQuarter] = useState("20211");
+    const [department, setDepartment] = useState("CMPSC");
+
+    const handleSubmit = (event) => {
+        event.preventDefault();
+        console.log("submit pressed");
+
+        fetchJSON(startQuarter, endQuarter, department)
+        .then((courseJSON)=> {
+            setOccupancyJson(courseJSON);
+        });
+
+    };
+
+    const handleStartQuarterOnChange = (event) => {
+        setStartQuarter(event.target.value);
+    };
+
+    const handleEndQuarterOnChange = (event) => {
+        setEndQuarter(event.target.value);
+    };
+
+    const handleDepartmentOnChange = (event) => {
+        setDepartment(event.target.value);
+    };
+
+    return (
+        <Form onSubmit={handleSubmit}>
+            <Form.Group controlId="CourseOccupancy.StartQuarter">
+                <Form.Label>Start Quarter</Form.Label>
+                <Form.Control as="select" onChange={handleStartQuarterOnChange} value={startQuarter} data-testid="select-quarter" >
+                    <option value="20211">W21</option>
+                    <option value="20204">F20</option>
+                </Form.Control>
+            </Form.Group>
+            <Form.Group controlId="CourseOccupancy.EndQuarter">
+                <Form.Label>End Quarter</Form.Label>
+                <Form.Control as="select" onChange={handleEndQuarterOnChange} value={endQuarter} data-testid="select-quarter" >
+                    <option value="20211">W21</option>
+                    <option value="20204">F20</option>
+                </Form.Control>
+            </Form.Group>
+            <Form.Group controlId="CourseOccupancy.Department">
+                <Form.Label>Department</Form.Label>
+                <Form.Control as="select" onChange={handleDepartmentOnChange} value={department}>
+                    <option value="CMPSC">CMPSC</option>
+                    <option value="MATH ">MATH</option>
+                </Form.Control>
+            </Form.Group>
+            <Button variant="primary" type="submit">
+                Submit
+            </Button>
+        </Form>
+    );
+};
+
+export default CourseOccupancyForm;

--- a/javascript/src/main/components/Statistics/CourseOccupancyForm.js
+++ b/javascript/src/main/components/Statistics/CourseOccupancyForm.js
@@ -11,7 +11,7 @@ const CourseOccupancyForm = ({ setOccupancyJson, fetchJSON }) => {
         event.preventDefault();
         console.log("submit pressed");
 
-        fetchJSON(startQuarter, endQuarter, department)
+        fetchJSON({startQuarter, endQuarter, department})
         .then((courseJSON)=> {
             setOccupancyJson(courseJSON);
         });
@@ -34,21 +34,21 @@ const CourseOccupancyForm = ({ setOccupancyJson, fetchJSON }) => {
         <Form onSubmit={handleSubmit}>
             <Form.Group controlId="CourseOccupancy.StartQuarter">
                 <Form.Label>Start Quarter</Form.Label>
-                <Form.Control as="select" onChange={handleStartQuarterOnChange} value={startQuarter} data-testid="select-quarter" >
+                <Form.Control as="select" onChange={handleStartQuarterOnChange} value={startQuarter} data-testid="select-start-quarter" >
                     <option value="20211">W21</option>
                     <option value="20204">F20</option>
                 </Form.Control>
             </Form.Group>
             <Form.Group controlId="CourseOccupancy.EndQuarter">
                 <Form.Label>End Quarter</Form.Label>
-                <Form.Control as="select" onChange={handleEndQuarterOnChange} value={endQuarter} data-testid="select-quarter" >
+                <Form.Control as="select" onChange={handleEndQuarterOnChange} value={endQuarter} data-testid="select-end-quarter" >
                     <option value="20211">W21</option>
                     <option value="20204">F20</option>
                 </Form.Control>
             </Form.Group>
             <Form.Group controlId="CourseOccupancy.Department">
                 <Form.Label>Department</Form.Label>
-                <Form.Control as="select" onChange={handleDepartmentOnChange} value={department}>
+                <Form.Control as="select" onChange={handleDepartmentOnChange} value={department} data-testid="select-department">
                     <option value="CMPSC">CMPSC</option>
                     <option value="MATH ">MATH</option>
                 </Form.Control>

--- a/javascript/src/main/components/Statistics/CourseOccupancyForm.js
+++ b/javascript/src/main/components/Statistics/CourseOccupancyForm.js
@@ -12,7 +12,6 @@ const CourseOccupancyForm = ({ setOccupancyJson, fetchJSON, onSubmit = () => {} 
 
     const handleSubmit = (event) => {
         event.preventDefault();
-        console.log("submit pressed");
         onSubmit();
         setLoading(true);
         fetchJSON({startQuarter, endQuarter, department})

--- a/javascript/src/main/components/Statistics/CourseOccupancyForm.js
+++ b/javascript/src/main/components/Statistics/CourseOccupancyForm.js
@@ -1,23 +1,25 @@
 import React, { useState } from "react";
-import { Form, Button } from "react-bootstrap";
+import { Form, Button, Spinner } from "react-bootstrap";
 import DepartmentFormSelect from "main/components/Statistics/DepartmentFormSelect";
 import QuarterFormSelect from "main/components/Statistics/QuarterFormSelect";
 
-const CourseOccupancyForm = ({ setOccupancyJson, fetchJSON }) => {
+const CourseOccupancyForm = ({ setOccupancyJson, fetchJSON, onSubmit = () => {} }) => {
 
     const [startQuarter, setStartQuarter] = useState("20204");
     const [endQuarter, setEndQuarter] = useState("20211");
     const [department, setDepartment] = useState("CMPSC");
+    const [loading, setLoading] = useState(false);
 
     const handleSubmit = (event) => {
         event.preventDefault();
         console.log("submit pressed");
-
+        onSubmit();
+        setLoading(true);
         fetchJSON({startQuarter, endQuarter, department})
         .then((courseJSON)=> {
             setOccupancyJson(courseJSON);
+            setLoading(false);
         });
-
     };
 
     return (
@@ -34,9 +36,10 @@ const CourseOccupancyForm = ({ setOccupancyJson, fetchJSON }) => {
                 <Form.Label>Department</Form.Label>
                 <DepartmentFormSelect handleSelect={setDepartment} value={department}/>
             </Form.Group>
-            <Button variant="primary" type="submit">
+            <Button variant="primary" type="submit" className={"text-center"} disabled={loading}>
                 Submit
             </Button>
+            {loading && <Spinner size={"sm"} style={{ marginLeft: "5px" }} animation="border" />}
         </Form>
     );
 };

--- a/javascript/src/main/components/Statistics/CourseOccupancyTable.js
+++ b/javascript/src/main/components/Statistics/CourseOccupancyTable.js
@@ -11,7 +11,10 @@ const CourseOccupancyTable = ({ data }) => {
     text: '# Enrolled'
   }, {
     dataField: 'maxEnrolled',
-    text: '# of Max Enrolled'
+    text: '# Total'
+  }, {
+    dataField: 'occupancy',
+    text: 'Occupancy'
   }
   ];
 

--- a/javascript/src/main/components/Statistics/CourseOccupancyTable.js
+++ b/javascript/src/main/components/Statistics/CourseOccupancyTable.js
@@ -1,20 +1,20 @@
 import React from "react";
 import BootstrapTable from 'react-bootstrap-table-next';
 
-const CourseOccupancyTable = ( {data} ) => {
-  
+const CourseOccupancyTable = ({ data }) => {
+
   const columns = [{
     dataField: 'quarter',
     text: 'Quarter'
-  },{
+  }, {
     dataField: 'enrolled',
     text: '# Enrolled'
-  },{
+  }, {
     dataField: 'maxEnrolled',
     text: '# of Max Enrolled'
   }
-];
-  
+  ];
+
   return (
     <BootstrapTable keyField='quarter' data={data} columns={columns} />
   );

--- a/javascript/src/main/components/Statistics/CourseOccupancyTable.js
+++ b/javascript/src/main/components/Statistics/CourseOccupancyTable.js
@@ -1,0 +1,23 @@
+import React from "react";
+import BootstrapTable from 'react-bootstrap-table-next';
+
+const CourseOccupancyTable = ( {data} ) => {
+  
+  const columns = [{
+    dataField: 'quarter',
+    text: 'Quarter'
+  },{
+    dataField: 'enrolled',
+    text: '# Enrolled'
+  },{
+    dataField: 'maxEnrolled',
+    text: '# of Max Enrolled'
+  }
+];
+  
+  return (
+    <BootstrapTable keyField='quarter' data={data} columns={columns} />
+  );
+};
+
+export default CourseOccupancyTable;

--- a/javascript/src/main/components/Statistics/CourseOccupancyTable.js
+++ b/javascript/src/main/components/Statistics/CourseOccupancyTable.js
@@ -1,20 +1,57 @@
 import React from "react";
 import BootstrapTable from 'react-bootstrap-table-next';
 
+const white = {
+  backgroundColor: '#ffffff'
+};
+
+const d2d4d7 = {
+  backgroundColor: '#d2d4d7'
+}
+
+const average = (arr) => {
+  return (arr.reduce((a, b) => parseInt(a) + parseInt(b), 0) / arr.length).toFixed(0);
+};
+
+const alternate = (cell, row, rowIndex, colIndex) => {
+  if (rowIndex % 2 === 0) 
+    return { backgroundColor: '#e9ecef' };
+  else
+    return { backgroundColor: '#edf0f2' };
+};
+
 const CourseOccupancyTable = ({ data }) => {
 
   const columns = [{
     dataField: 'quarter',
-    text: 'Quarter'
+    text: 'Quarter',
+    footer: 'Average',
+    style: alternate,
+    headerStyle: white,
+    footerStyle: d2d4d7
   }, {
     dataField: 'enrolled',
-    text: '# Enrolled'
+    text: '# Enrolled',
+    style: alternate,
+    footer: average,
+    headerStyle: white,
+    footerStyle: d2d4d7
   }, {
     dataField: 'maxEnrolled',
-    text: '# Total'
+    text: '# Total',
+    style: alternate,
+    footer: average,
+    headerStyle: white,
+    footerStyle: d2d4d7
   }, {
     dataField: 'occupancy',
-    text: 'Occupancy'
+    text: 'Occupancy',
+    sort: true,
+    style: alternate,
+    formatter: (cell) => cell + "%",
+    footer: data => average(data) + "%",
+    headerStyle: white,
+    footerStyle: d2d4d7
   }
   ];
 

--- a/javascript/src/main/pages/Statistics/CourseOccupancy.js
+++ b/javascript/src/main/pages/Statistics/CourseOccupancy.js
@@ -1,0 +1,28 @@
+import React from "react";
+import { useState } from "react";
+import { Jumbotron } from "react-bootstrap";
+import { fetchCourseOccupancy } from "main/services/statisticsService";
+import CourseOccupancyForm from "main/components/Statistics/CourseOccupancyForm";
+import CourseOccupancyTable from "main/components/Statistics/CourseOccupancyTable";
+
+const CourseOccupancy = () => {
+    const [tableVisibility, setTableVisibility] = useState(false);
+    const [tableData, setTableData] = useState([]);
+
+    const setJsonTableData = (json) => {
+        setTableData(json);
+        setTableVisibility(true);
+    }
+
+    return (
+        <Jumbotron>
+            <div className="text-left">
+                <h5>Course Occupancy by Department</h5>
+                <CourseOccupancyForm setOccupancyJson={setJsonTableData} fetchJSON={fetchCourseOccupancy} />
+            </div>
+            {tableVisibility ? (<CourseOccupancyTable data={tableData} />) : (<div>No</div>)}
+        </Jumbotron>
+    );
+};
+
+export default CourseOccupancy;

--- a/javascript/src/main/pages/Statistics/CourseOccupancy.js
+++ b/javascript/src/main/pages/Statistics/CourseOccupancy.js
@@ -20,7 +20,7 @@ const CourseOccupancy = () => {
                 <h5>Course Occupancy by Department</h5>
                 <CourseOccupancyForm setOccupancyJson={setJsonTableData} fetchJSON={fetchCourseOccupancy} />
             </div>
-            {tableVisibility ? (<CourseOccupancyTable data={tableData} />) : (<div>No</div>)}
+            {tableVisibility && (<CourseOccupancyTable data={tableData} />)}
         </Jumbotron>
     );
 };

--- a/javascript/src/main/pages/Statistics/CourseOccupancy.js
+++ b/javascript/src/main/pages/Statistics/CourseOccupancy.js
@@ -6,6 +6,13 @@ import CourseOccupancyForm from "main/components/Statistics/CourseOccupancyForm"
 import CourseOccupancyTable from "main/components/Statistics/CourseOccupancyTable";
 import { fromFormat } from "main/components/Statistics/QuarterFormSelect";
 
+const calcPercent = (first, second) => {
+    first = parseInt(first);
+    second = parseInt(second);
+
+    return (first / second * 100).toFixed(0);
+};
+
 const CourseOccupancy = () => {
     const [tableVisibility, setTableVisibility] = useState(false);
     const [tableData, setTableData] = useState([]);
@@ -13,6 +20,7 @@ const CourseOccupancy = () => {
     const setJsonTableData = (json) => {
         json.forEach((item) => {
             item["quarter"] = fromFormat(item["quarter"]);
+            item["occupancy"] = calcPercent(item["enrolled"], item["maxEnrolled"]);
         });
         setTableData(json);
         setTableVisibility(true);

--- a/javascript/src/main/pages/Statistics/CourseOccupancy.js
+++ b/javascript/src/main/pages/Statistics/CourseOccupancy.js
@@ -1,26 +1,32 @@
 import React from "react";
 import { useState } from "react";
-import { Jumbotron } from "react-bootstrap";
+import { Jumbotron, Container } from "react-bootstrap";
 import { fetchCourseOccupancy } from "main/services/statisticsService";
 import CourseOccupancyForm from "main/components/Statistics/CourseOccupancyForm";
 import CourseOccupancyTable from "main/components/Statistics/CourseOccupancyTable";
+import { fromFormat } from "main/components/Statistics/QuarterFormSelect";
 
 const CourseOccupancy = () => {
     const [tableVisibility, setTableVisibility] = useState(false);
     const [tableData, setTableData] = useState([]);
 
     const setJsonTableData = (json) => {
+        json.forEach((item) => {
+            item["quarter"] = fromFormat(item["quarter"]);
+        });
         setTableData(json);
         setTableVisibility(true);
     }
 
     return (
         <Jumbotron>
-            <div className="text-left">
-                <h5>Course Occupancy by Department</h5>
+            <Container className="text-left">
+                <h1>Course Occupancy by Department</h1>
                 <CourseOccupancyForm setOccupancyJson={setJsonTableData} fetchJSON={fetchCourseOccupancy} />
-            </div>
-            {tableVisibility && (<CourseOccupancyTable data={tableData} />)}
+            </Container>
+            <Container>
+                {tableVisibility && (<CourseOccupancyTable data={tableData} />)}
+            </Container>
         </Jumbotron>
     );
 };

--- a/javascript/src/main/pages/Statistics/CourseOccupancy.js
+++ b/javascript/src/main/pages/Statistics/CourseOccupancy.js
@@ -1,10 +1,11 @@
 import React from "react";
 import { useState } from "react";
-import { Jumbotron, Container } from "react-bootstrap";
+import { Jumbotron, Container, Spinner } from "react-bootstrap";
 import { fetchCourseOccupancy } from "main/services/statisticsService";
 import CourseOccupancyForm from "main/components/Statistics/CourseOccupancyForm";
 import CourseOccupancyTable from "main/components/Statistics/CourseOccupancyTable";
 import { fromFormat } from "main/components/Statistics/QuarterFormSelect";
+import Loading from "main/components/Loading/Loading";
 
 const calcPercent = (first, second) => {
     first = parseInt(first);
@@ -30,9 +31,9 @@ const CourseOccupancy = () => {
         <Jumbotron>
             <Container className="text-left">
                 <h1>Course Occupancy by Department</h1>
-                <CourseOccupancyForm setOccupancyJson={setJsonTableData} fetchJSON={fetchCourseOccupancy} />
+                <CourseOccupancyForm setOccupancyJson={setJsonTableData} fetchJSON={fetchCourseOccupancy} onSubmit={() => { setTableVisibility(false) }}/>
             </Container>
-            <Container>
+            <Container style={{ marginTop: "20px" }} className={"text-left"}>
                 {tableVisibility && (<CourseOccupancyTable data={tableData} />)}
             </Container>
         </Jumbotron>

--- a/javascript/src/main/pages/Statistics/CourseOccupancy.js
+++ b/javascript/src/main/pages/Statistics/CourseOccupancy.js
@@ -33,8 +33,8 @@ const CourseOccupancy = () => {
                 <h1>Course Occupancy by Department</h1>
                 <CourseOccupancyForm setOccupancyJson={setJsonTableData} fetchJSON={fetchCourseOccupancy} onSubmit={() => { setTableVisibility(false) }}/>
             </Container>
-            <Container style={{ marginTop: "20px" }} className={"text-left"}>
-                {tableVisibility && (<CourseOccupancyTable data={tableData} />)}
+            <Container style={{ marginTop: "20px" }} className={"text-center"}>
+                {tableVisibility && (tableData.length ? <CourseOccupancyTable data={tableData} /> : "There are no results!")}
             </Container>
         </Jumbotron>
     );

--- a/javascript/src/main/services/statisticsService.js
+++ b/javascript/src/main/services/statisticsService.js
@@ -12,6 +12,13 @@ const fetchClassSize = async (fields) => {
     return classSizeResponse.json();
 }
 
-export {fetchClassSize, fetchDivisionOccupancy };
+const fetchCourseOccupancy = async(startQuarter, endQuarter, dept) => {
+    const url = `/api/public/statistics/courseOccupancy?startQuarter=${encodeURIComponent(startQuarter)}&endQuarter=${encodeURIComponent(endQuarter)}&department=${encodeURIComponent(dept)}`;
+    const response = await fetch(url);
+
+    return response.json();
+}
+
+export { fetchClassSize, fetchDivisionOccupancy, fetchCourseOccupancy };
 
     

--- a/javascript/src/main/services/statisticsService.js
+++ b/javascript/src/main/services/statisticsService.js
@@ -12,13 +12,11 @@ const fetchClassSize = async (fields) => {
     return classSizeResponse.json();
 }
 
-const fetchCourseOccupancy = async(startQuarter, endQuarter, dept) => {
-    const url = `/api/public/statistics/courseOccupancy?startQuarter=${encodeURIComponent(startQuarter)}&endQuarter=${encodeURIComponent(endQuarter)}&department=${encodeURIComponent(dept)}`;
+const fetchCourseOccupancy = async(fields) => {
+    const url = `/api/public/statistics/courseOccupancy?startQuarter=${encodeURIComponent(fields.startQuarter)}&endQuarter=${encodeURIComponent(fields.endQuarter)}&department=${encodeURIComponent(fields.department)}`;
     const response = await fetch(url);
 
     return response.json();
 }
 
 export { fetchClassSize, fetchDivisionOccupancy, fetchCourseOccupancy };
-
-    

--- a/javascript/src/test/components/Statistics/CourseOccupancyForm.test.js
+++ b/javascript/src/test/components/Statistics/CourseOccupancyForm.test.js
@@ -1,0 +1,83 @@
+import React from "react";
+import { render, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import CourseOccupancyForm from "main/components/Statistics/CourseOccupancyForm";
+
+describe("CourseOccupancyForm tests", () => {
+
+    test("renders without crashing", () => {
+        render(<CourseOccupancyForm />);
+    });
+
+    test("when I select a start quarter, the state for start quarter changes", () => {
+        const { getByTestId } = render(<CourseOccupancyForm />);
+        const selectQuarter = getByTestId("select-start-quarter")
+        userEvent.selectOptions(selectQuarter, "20204");
+        expect(selectQuarter.value).toBe("20204");
+    });
+
+    test("when I select a end quarter, the state for end quarter changes", () => {
+        const { getByTestId } = render(<CourseOccupancyForm />);
+        const selectQuarter = getByTestId("select-end-quarter")
+        userEvent.selectOptions(selectQuarter, "20204");
+        expect(selectQuarter.value).toBe("20204");
+    });
+
+    test("when I select a department, the state for department changes", () => {
+        const { getByTestId } = render(<CourseOccupancyForm />);
+        const selectDepartment = getByTestId("select-department")
+        userEvent.selectOptions(selectDepartment, "CMPSC");
+        expect(selectDepartment.value).toBe("CMPSC");
+    });
+
+    test("when I click submit, the right stuff happens", async () => {
+
+        const sampleReturnValue = {
+            "sampleKey": "sampleValue"
+        };
+
+        // Create spy functions (aka jest function, magic function)
+        // The function doesn't have any implementation unless
+        // we specify one.  But it does keep track of whether 
+        // it was called, how many times it was called,
+        // and what it was passed.
+
+        const setOccupancyJSON = jest.fn();
+        const fetchJSONSpy = jest.fn();
+
+        fetchJSONSpy.mockResolvedValue(sampleReturnValue);
+
+        const { getByText, getByTestId } = render(
+            <CourseOccupancyForm setOccupancyJson={setOccupancyJSON} fetchJSON={fetchJSONSpy} />
+        );
+
+        const expectedFields = {
+            startQuarter: "20204",
+            endQuarter: "20211",
+            department: "CMPSC",
+        };
+
+        const startQuarter = getByTestId("select-start-quarter");
+        userEvent.selectOptions(startQuarter, "20204");
+        const endQuarter = getByTestId("select-end-quarter");
+        userEvent.selectOptions(endQuarter, "20211");
+        const selectDepartment = getByTestId("select-department")
+        userEvent.selectOptions(selectDepartment, "CMPSC");
+
+        const submitButton = getByText("Submit");
+        userEvent.click(submitButton);
+
+        // we need to be careful not to assert this expectation
+        // until all of the async promises are resolved
+        await waitFor(() => expect(setOccupancyJSON).toHaveBeenCalledTimes(1));
+        await waitFor(() => expect(fetchJSONSpy).toHaveBeenCalledTimes(1));
+
+        // assert that ourSpy was called with the right value
+        expect(setOccupancyJSON).toHaveBeenCalledWith(sampleReturnValue);
+        expect(fetchJSONSpy).toHaveBeenCalledWith(expectedFields);
+
+    });
+
+});
+

--- a/javascript/src/test/components/Statistics/CourseOccupancyForm.test.js
+++ b/javascript/src/test/components/Statistics/CourseOccupancyForm.test.js
@@ -13,15 +13,29 @@ describe("CourseOccupancyForm tests", () => {
     test("when I select a start quarter, the state for start quarter changes", () => {
         const { getByTestId } = render(<CourseOccupancyForm />);
         const selectQuarter = getByTestId("select-start-quarter")
-        userEvent.selectOptions(selectQuarter, "20204");
-        expect(selectQuarter.value).toBe("20204");
+        userEvent.selectOptions(selectQuarter, "3");
+        expect(selectQuarter.value).toBe("3");
     });
 
     test("when I select a end quarter, the state for end quarter changes", () => {
         const { getByTestId } = render(<CourseOccupancyForm />);
         const selectQuarter = getByTestId("select-end-quarter")
-        userEvent.selectOptions(selectQuarter, "20204");
-        expect(selectQuarter.value).toBe("20204");
+        userEvent.selectOptions(selectQuarter, "3");
+        expect(selectQuarter.value).toBe("3");
+    });
+
+    test("when I select a start quarter year, the state for start quarter year changes", () => {
+        const { getByTestId } = render(<CourseOccupancyForm />);
+        const selectQuarter = getByTestId("select-start-year")
+        userEvent.selectOptions(selectQuarter, "2019");
+        expect(selectQuarter.value).toBe("2019");
+    });
+
+    test("when I select a end quarter year, the state for end quarter year changes", () => {
+        const { getByTestId } = render(<CourseOccupancyForm />);
+        const selectQuarter = getByTestId("select-end-year")
+        userEvent.selectOptions(selectQuarter, "2019");
+        expect(selectQuarter.value).toBe("2019");
     });
 
     test("when I select a department, the state for department changes", () => {
@@ -57,13 +71,6 @@ describe("CourseOccupancyForm tests", () => {
             endQuarter: "20211",
             department: "CMPSC",
         };
-
-        const startQuarter = getByTestId("select-start-quarter");
-        userEvent.selectOptions(startQuarter, "20204");
-        const endQuarter = getByTestId("select-end-quarter");
-        userEvent.selectOptions(endQuarter, "20211");
-        const selectDepartment = getByTestId("select-department")
-        userEvent.selectOptions(selectDepartment, "CMPSC");
 
         const submitButton = getByText("Submit");
         userEvent.click(submitButton);

--- a/javascript/src/test/components/Statistics/CourseOccupancyTable.test.js
+++ b/javascript/src/test/components/Statistics/CourseOccupancyTable.test.js
@@ -1,0 +1,9 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import CourseOccupancyTable from "main/components/Statistics/CourseOccupancyTable";
+
+describe("CourseOccupancyTable tests", () => {
+  test("renders without crashing", () => {
+    render(<CourseOccupancyTable data={[]} />);
+  });
+});

--- a/javascript/src/test/pages/Statistics/CourseOccupancy.test.js
+++ b/javascript/src/test/pages/Statistics/CourseOccupancy.test.js
@@ -18,6 +18,11 @@ describe("CourseOccupancy page tests", () => {
       "quarter": "20211",
       "enrolled": "100",
       "maxEnrolled": "200"
+    },
+    {
+      "quarter": "20212",
+      "enrolled": "100",
+      "maxEnrolled": "200"
     }];
 
     fetchCourseOccupancy.mockResolvedValue(sampleReturnValue);
@@ -26,5 +31,17 @@ describe("CourseOccupancy page tests", () => {
     userEvent.click(submitButton);
 
     await findByText("WINTER 2021");
+  });
+
+  test("CourseOccupancy no results is displayed for empty results", async () => {
+    const { findByText } = render(<CourseOccupancy />);
+    const sampleReturnValue = [];
+
+    fetchCourseOccupancy.mockResolvedValue(sampleReturnValue);
+
+    const submitButton = await findByText("Submit");
+    userEvent.click(submitButton);
+
+    await findByText("There are no results!");
   });
 });

--- a/javascript/src/test/pages/Statistics/CourseOccupancy.test.js
+++ b/javascript/src/test/pages/Statistics/CourseOccupancy.test.js
@@ -1,9 +1,30 @@
 import React from "react";
 import { render } from "@testing-library/react";
 import CourseOccupancy from "main/pages/Statistics/CourseOccupancy";
+import userEvent from "@testing-library/user-event";
+import { act } from 'react-dom/test-utils';
+
+import { fetchCourseOccupancy } from "main/services/statisticsService";
+jest.mock("main/services/statisticsService");
 
 describe("CourseOccupancy page tests", () => {
   test("renders without crashing", () => {
     render(<CourseOccupancy />);
+  });
+
+  test("CourseOccupancy table appears with data after pressing submit", async () => {
+    const { findByText } = render(<CourseOccupancy />);
+    const sampleReturnValue = [{
+      "quarter": "20211",
+      "enrolled": "100",
+      "maxEnrolled": "200"
+    }];
+
+    fetchCourseOccupancy.mockResolvedValue(sampleReturnValue);
+
+    const submitButton = await findByText("Submit");
+    userEvent.click(submitButton);
+
+    await findByText("WINTER 2021");
   });
 });

--- a/javascript/src/test/pages/Statistics/CourseOccupancy.test.js
+++ b/javascript/src/test/pages/Statistics/CourseOccupancy.test.js
@@ -1,0 +1,9 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import CourseOccupancy from "main/pages/Statistics/CourseOccupancy";
+
+describe("CourseOccupancy page tests", () => {
+  test("renders without crashing", () => {
+    render(<CourseOccupancy />);
+  });
+});

--- a/javascript/src/test/services/statisticsService.test.js
+++ b/javascript/src/test/services/statisticsService.test.js
@@ -1,4 +1,4 @@
-import { fetchDivisionOccupancy } from "main/services/statisticsService";
+import { fetchDivisionOccupancy, fetchCourseOccupancy } from "main/services/statisticsService";
 
 import fetch from "isomorphic-unfetch";
 jest.mock("isomorphic-unfetch");
@@ -25,6 +25,32 @@ describe("courseCount tests",  () => {
     };
 
     const result = await fetchDivisionOccupancy(expectedFields);
+    expect(result).toBe(sampleReturnValue);
+
+  });
+});
+
+describe("courseCount tests",  () => {
+  test("fetchCourseOccupancy", async () => {
+    
+    const sampleReturnValue = {
+        "sampleKey": "sampleValue"
+    };
+
+    fetch.mockResolvedValue({
+        status: 200,
+        json: () => {
+          return sampleReturnValue;
+        },
+      });
+
+    const expectedFields = {
+        startQuarter: "20201",
+        endQuarter: "20204",
+        department: "MATH "
+    };
+
+    const result = await fetchCourseOccupancy(expectedFields);
     expect(result).toBe(sampleReturnValue);
 
   });

--- a/src/main/java/edu/ucsb/courses/controllers/StatisticsController.java
+++ b/src/main/java/edu/ucsb/courses/controllers/StatisticsController.java
@@ -134,12 +134,13 @@ public class StatisticsController {
             throws JsonProcessingException {
         MatchOperation matchOperation = match(Criteria.where("quarter").gte(startQuarter).lte(endQuarter)
                 .and("deptCode").is(department).and("instructionType").is("LEC"));
-        UnwindOperation unwindOperation = unwind("$classSections", false);
+        UnwindOperation unwindOperation = unwind("$classSections", "index", false);
+        MatchOperation onlySections = match(Criteria.where("index").ne(0));
         GroupOperation groupOperation = group("$quarter").sum("$classSections.enrolledTotal").as("enrolled")
                 .sum("$classSections.maxEnroll").as("maxEnrolled");
         SortOperation sort = sort(Sort.by(Direction.ASC, "_id"));
 
-        Aggregation aggregation = newAggregation(matchOperation, unwindOperation, groupOperation, sort);
+        Aggregation aggregation = newAggregation(matchOperation, unwindOperation, onlySections, groupOperation, sort);
 
         AggregationResults<QuarterOccupancy> result = mongoTemplate.aggregate(aggregation, "courses",
                 QuarterOccupancy.class);

--- a/src/main/java/edu/ucsb/courses/documents/statistics/QuarterOccupancy.java
+++ b/src/main/java/edu/ucsb/courses/documents/statistics/QuarterOccupancy.java
@@ -1,7 +1,9 @@
 package edu.ucsb.courses.documents.statistics;
 
 import java.util.List;
+import java.util.Objects;
 
+import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,12 +58,7 @@ public class QuarterOccupancy {
 
     @Override
     public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((_id == null) ? 0 : _id.hashCode());
-        result = prime * result + ((enrolled == null) ? 0 : enrolled.hashCode());
-        result = prime * result + ((maxEnrolled == null) ? 0 : maxEnrolled.hashCode());
-        return result;
+        return Objects.hash(_id, enrolled, maxEnrolled);
     }
 
     @Override
@@ -73,22 +70,10 @@ public class QuarterOccupancy {
         if (getClass() != obj.getClass())
             return false;
         QuarterOccupancy other = (QuarterOccupancy) obj;
-        if (_id == null) {
-            if (other._id != null)
-                return false;
-        } else if (!_id.equals(other._id))
-            return false;
-        if (enrolled == null) {
-            if (other.enrolled != null)
-                return false;
-        } else if (!enrolled.equals(other.enrolled))
-            return false;
-        if (maxEnrolled == null) {
-            if (other.maxEnrolled != null)
-                return false;
-        } else if (!maxEnrolled.equals(other.maxEnrolled))
-            return false;
-        return true;
+        EqualsBuilder builder = new EqualsBuilder();
+        builder.append(_id, other._id).append(enrolled, other.enrolled).append(maxEnrolled, other.maxEnrolled);
+        
+        return builder.build();
     }
     
     @Override

--- a/src/main/java/edu/ucsb/courses/documents/statistics/QuarterOccupancy.java
+++ b/src/main/java/edu/ucsb/courses/documents/statistics/QuarterOccupancy.java
@@ -1,0 +1,72 @@
+package edu.ucsb.courses.documents.statistics;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class QuarterOccupancy {
+    @JsonProperty("quarter")
+    private String _id;
+    private String enrolled;
+    private String maxEnrolled;
+
+    public String get_id() {
+        return _id;
+    }
+
+    public void set_id(String _id) {
+        this._id = _id;
+    }
+
+    public String getEnrolled() {
+        return enrolled;
+    }
+
+    public void setEnrolled(String enrolled) {
+        this.enrolled = enrolled;
+    }
+
+    public String getMaxEnrolled() {
+        return maxEnrolled;
+    }
+
+    public void setMaxEnrolled(String maxEnrolled) {
+        this.maxEnrolled = maxEnrolled;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((_id == null) ? 0 : _id.hashCode());
+        result = prime * result + ((enrolled == null) ? 0 : enrolled.hashCode());
+        result = prime * result + ((maxEnrolled == null) ? 0 : maxEnrolled.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        QuarterOccupancy other = (QuarterOccupancy) obj;
+        if (_id == null) {
+            if (other._id != null)
+                return false;
+        } else if (!_id.equals(other._id))
+            return false;
+        if (enrolled == null) {
+            if (other.enrolled != null)
+                return false;
+        } else if (!enrolled.equals(other.enrolled))
+            return false;
+        if (maxEnrolled == null) {
+            if (other.maxEnrolled != null)
+                return false;
+        } else if (!maxEnrolled.equals(other.maxEnrolled))
+            return false;
+        return true;
+    }
+    
+}

--- a/src/main/java/edu/ucsb/courses/documents/statistics/QuarterOccupancy.java
+++ b/src/main/java/edu/ucsb/courses/documents/statistics/QuarterOccupancy.java
@@ -1,12 +1,34 @@
 package edu.ucsb.courses.documents.statistics;
 
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class QuarterOccupancy {
+    
+    private static Logger logger = LoggerFactory.getLogger(QuarterOccupancy.class);
+    
     @JsonProperty("quarter")
     private String _id;
     private String enrolled;
     private String maxEnrolled;
+    
+    public QuarterOccupancy() {
+        
+    }
+    
+    public QuarterOccupancy(String _id, String enrolled, String maxEnrolled) {
+        this._id = _id;
+        this.enrolled = enrolled;
+        this.maxEnrolled = maxEnrolled;
+    }
 
     public String get_id() {
         return _id;
@@ -67,6 +89,28 @@ public class QuarterOccupancy {
         } else if (!maxEnrolled.equals(other.maxEnrolled))
             return false;
         return true;
+    }
+    
+    @Override
+    public String toString() {
+        return "{" +
+            " quarter='" + _id + "'" +
+            ", enrolled='" + enrolled + "'" +
+            ", maxEnrolled='" + maxEnrolled + "'" +
+            "}";
+    }
+    
+    public static List<QuarterOccupancy> listFromJSON(String json) {
+        try {
+            ObjectMapper objectMapper = new ObjectMapper();
+            objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+            List<QuarterOccupancy> lqd = objectMapper.readValue(json, new TypeReference<List<QuarterOccupancy>>(){});
+            return lqd;
+        } catch (JsonProcessingException jpe) {
+            logger.error("JsonProcessingException:" + jpe);
+            return null;
+        }
+        
     }
     
 }

--- a/src/main/java/edu/ucsb/courses/repositories/ArchivedCourseRepository.java
+++ b/src/main/java/edu/ucsb/courses/repositories/ArchivedCourseRepository.java
@@ -1,14 +1,16 @@
 package edu.ucsb.courses.repositories;
 
+import java.util.List;
+import java.util.Optional;
+
 import org.bson.types.ObjectId;
+import org.springframework.data.mongodb.repository.Aggregation;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.data.mongodb.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import edu.ucsb.courses.documents.Course;
-
-import java.util.List;
-import java.util.Optional;
+import edu.ucsb.courses.documents.statistics.QuarterOccupancy;
 
 @Repository
 public interface ArchivedCourseRepository extends MongoRepository<Course, ObjectId> {
@@ -104,4 +106,23 @@ public interface ArchivedCourseRepository extends MongoRepository<Course, Object
      */                                                       
      @Query("{'quarter': ?0, 'deptCode': ?1}")
      List<Course> findByQuarterAndDepartment(String quarter, String dept);
+     
+     /**
+      * Returns a list of {@link QuarterOccupancy} from the requested
+      * quarter interval and department
+      * 
+      * @param startQuarter quarter formatted as YYYYQ string
+      * @param endQuarter quarter formatted as YYYYQ string
+      * @param department the department code 
+      * @return a list of {@link QuarterOccupancy}
+      */
+     @Aggregation(pipeline= {
+             "{$match:{'quarter':{'$gte':?0,'$lte':?1},'deptCode':?2,'instructionType':'LEC',}}",
+             "{$addFields:{'classSize':{'$size':'$classSections'}}}",
+             "{$unwind:{'path':'$classSections','includeArrayIndex':'index','preserveNullAndEmptyArrays':false}}",
+             "{$match:{'classSections.courseCancelled':{$eq:null},'$or':[{'index':{'$ne':0}},{'$and':[{'classSize':1},{'index':0}]}]}}",
+             "{$group:{'_id':'$quarter','enrolled':{$sum:'$classSections.enrolledTotal'},'maxEnrolled':{$sum:'$classSections.maxEnroll'}}}",
+             "{$sort:{_id:1}}"
+     })
+     List<QuarterOccupancy> findOccupancyByQuarterIntervalAndDepartment(String startQuarter, String endQuarter, String department);
 }

--- a/src/test/java/edu/ucsb/courses/controllers/StatisticsControllerTests.java
+++ b/src/test/java/edu/ucsb/courses/controllers/StatisticsControllerTests.java
@@ -27,6 +27,7 @@ import edu.ucsb.courses.documents.statistics.AvgClassSize;
 import edu.ucsb.courses.documents.statistics.DivisionOccupancy;
 import edu.ucsb.courses.documents.statistics.QuarterDept;
 import edu.ucsb.courses.documents.statistics.QuarterOccupancy;
+import edu.ucsb.courses.repositories.ArchivedCourseRepository;
 
 // @Import(SecurityConfig.class) applies the security rules 
 // so that /api/public/** endpoints don't require authentication.
@@ -41,6 +42,9 @@ public class StatisticsControllerTests {
 
     @MockBean
     private MongoTemplate mongoTemplate;
+    
+    @MockBean
+    private ArchivedCourseRepository courseRepo;
     
     @Test
     public void test_courseCount() throws Exception {
@@ -72,8 +76,7 @@ public class StatisticsControllerTests {
         qdList.add(new QuarterOccupancy("20204", "100", "200"));
         AggregationResults<QuarterOccupancy> fakeResults = new AggregationResults<QuarterOccupancy>(qdList,
                 fakeRawResults);
-
-        when(mongoTemplate.aggregate(any(Aggregation.class), eq("courses"), any(Class.class))).thenReturn(fakeResults);
+        when(courseRepo.findOccupancyByQuarterIntervalAndDepartment(any(String.class), any(String.class), any(String.class))).thenReturn(qdList);
 
         MvcResult response = mockMvc
                 .perform(get(url).queryParam("startQuarter", "20204").queryParam("endQuarter", "20211")

--- a/src/test/java/edu/ucsb/courses/controllers/StatisticsControllerTests.java
+++ b/src/test/java/edu/ucsb/courses/controllers/StatisticsControllerTests.java
@@ -1,38 +1,32 @@
 package edu.ucsb.courses.controllers;
 
-import edu.ucsb.courses.config.SecurityConfig;
-import edu.ucsb.courses.documents.Course;
-import edu.ucsb.courses.documents.CoursePage;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import edu.ucsb.courses.documents.statistics.DivisionOccupancy;
-import edu.ucsb.courses.documents.statistics.QuarterDept;
-import edu.ucsb.courses.documents.statistics.AvgClassSize;
-import edu.ucsb.courses.repositories.ArchivedCourseRepository;
+import java.util.ArrayList;
+import java.util.List;
 
-import org.bson.Document;
 import org.junit.jupiter.api.Test;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.mongodb.core.MongoTemplate;
-
 import org.springframework.data.mongodb.core.aggregation.Aggregation;
 import org.springframework.data.mongodb.core.aggregation.AggregationResults;
-
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-
-import java.util.ArrayList;
-import java.util.List;
+import edu.ucsb.courses.config.SecurityConfig;
+import edu.ucsb.courses.documents.Course;
+import edu.ucsb.courses.documents.statistics.AvgClassSize;
+import edu.ucsb.courses.documents.statistics.DivisionOccupancy;
+import edu.ucsb.courses.documents.statistics.QuarterDept;
+import edu.ucsb.courses.documents.statistics.QuarterOccupancy;
 
 // @Import(SecurityConfig.class) applies the security rules 
 // so that /api/public/** endpoints don't require authentication.
@@ -47,7 +41,7 @@ public class StatisticsControllerTests {
 
     @MockBean
     private MongoTemplate mongoTemplate;
-
+    
     @Test
     public void test_courseCount() throws Exception {
         List<Course> expectedResult = new ArrayList<Course>();
@@ -65,6 +59,28 @@ public class StatisticsControllerTests {
                 .andReturn();
         String responseString = response.getResponse().getContentAsString();
         List<QuarterDept> resultFromPage = QuarterDept.listFromJSON(responseString);
+
+        assertEquals(qdList, resultFromPage);
+    }
+    
+    @Test
+    public void test_CourseOccupancy() throws Exception {
+        String url = "/api/public/statistics/courseOccupancy";
+
+        org.bson.Document fakeRawResults = new org.bson.Document();
+        List<QuarterOccupancy> qdList = new ArrayList<QuarterOccupancy>();
+        qdList.add(new QuarterOccupancy("20204", "100", "200"));
+        AggregationResults<QuarterOccupancy> fakeResults = new AggregationResults<QuarterOccupancy>(qdList,
+                fakeRawResults);
+
+        when(mongoTemplate.aggregate(any(Aggregation.class), eq("courses"), any(Class.class))).thenReturn(fakeResults);
+
+        MvcResult response = mockMvc
+                .perform(get(url).queryParam("startQuarter", "20204").queryParam("endQuarter", "20211")
+                        .queryParam("department", "CMPSC").contentType("application/json"))
+                .andExpect(status().isOk()).andReturn();
+        String responseString = response.getResponse().getContentAsString();
+        List<QuarterOccupancy> resultFromPage = QuarterOccupancy.listFromJSON(responseString);
 
         assertEquals(qdList, resultFromPage);
     }

--- a/src/test/java/edu/ucsb/courses/documents/statistics/QuarterOccupancyTests.java
+++ b/src/test/java/edu/ucsb/courses/documents/statistics/QuarterOccupancyTests.java
@@ -1,0 +1,69 @@
+package edu.ucsb.courses.documents.statistics;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import net.codebox.javabeantester.JavaBeanTester;
+
+public class QuarterOccupancyTests {
+
+    @Test
+    public void testGettersAndSetters() throws Exception {
+        // See: https://github.com/codebox/javabean-tester
+        // The classes that should NOT be tested with the Bean are the
+        // ones that set and get List<> instances
+        JavaBeanTester.test(QuarterOccupancy.class);
+    }
+
+    @Test
+    public void test_notEqualNull() throws Exception {
+        QuarterOccupancy qd = new QuarterOccupancy();
+        assertNotEquals(qd, null);
+    }
+
+    @Test
+    public void test_notEqualAnotherClass() throws Exception {
+        QuarterOccupancy qd = new QuarterOccupancy();
+        assertNotEquals(qd, new Object());
+    }
+
+    @Test
+    public void test_equalsSelf() throws Exception {
+        QuarterOccupancy qd = new QuarterOccupancy("20204", "100", "200");
+        assertEquals(qd, qd);
+    }
+
+    @Test
+    public void test_equalsAnother() throws Exception {
+        QuarterOccupancy qd1 = new QuarterOccupancy("20211", "100", "200");
+        QuarterOccupancy qd2 = new QuarterOccupancy("20204", "100", "200");
+        qd1.set_id("20204");
+        assertEquals(qd1, qd2);
+    }
+
+    @Test
+    public void test_hashCode() throws Exception {
+        QuarterOccupancy qd1 = new QuarterOccupancy("20211", "100", "200");
+        QuarterOccupancy qd2 = new QuarterOccupancy("20211", "100", "200");
+        assertEquals(qd1.hashCode(), qd2.hashCode());
+    }
+
+    @Test
+    public void test_toString() throws Exception {
+        QuarterOccupancy qd1 = new QuarterOccupancy("20211", "100", "200");
+        String expected="{ quarter='20211', enrolled='100', maxEnrolled='200'}";
+        assertEquals(expected, qd1.toString());
+    }
+
+    @Test
+    public void test_fromJSON_withError() throws Exception {
+        String badJSON = "this is not good json!";
+        List<QuarterOccupancy> lqd = QuarterOccupancy.listFromJSON(badJSON);
+        assertNull(lqd);
+    }
+}


### PR DESCRIPTION
This PR implements the "Course Occupancy By Department" statistic page, where a user can select a start and end quarter along with the department to get the amount of enrolled, amount of max enrollment, and occupancy percentage across all regular classes in the department. Closes #44 

![course-search-course-occupancy](https://user-images.githubusercontent.com/1119017/101965792-b28dc480-3bca-11eb-8149-4cc2dac36352.gif)
