### PR TITLE
5pm b schedule entity and repository with controller

### DIFF
--- a/src/main/java/edu/ucsb/courses/controllers/ScheduleController.java
+++ b/src/main/java/edu/ucsb/courses/controllers/ScheduleController.java
@@ -1,0 +1,129 @@
+package edu.ucsb.courses.controllers;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import javax.validation.Valid;
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import edu.ucsb.courses.advice.AuthControllerAdvice;
+import edu.ucsb.courses.entities.AppUser;
+import edu.ucsb.courses.entities.Schedule;
+import edu.ucsb.courses.services.UCSBCurriculumService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.DeleteMapping;
+
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+
+import edu.ucsb.courses.documents.Course;
+import edu.ucsb.courses.documents.CoursePage;
+import edu.ucsb.courses.repositories.ScheduleRepository;
+
+
+@RestController
+@RequestMapping("/api/public")
+public class ScheduleController {
+    private final Logger logger = LoggerFactory.getLogger(BasicSearchController.class);
+
+    private ObjectMapper mapper = new ObjectMapper();
+
+    @Autowired
+    ScheduleRepository scheduleRepository;
+
+    @Autowired
+    AuthControllerAdvice authController;
+
+    @PostMapping(value = "/createSchedule", produces = "application/json")
+    public ResponseEntity<String> createSchedule(@RequestParam String name,
+                                                 @RequestParam String description,
+                                                 @RequestParam String quarter,
+                                                 @RequestHeader("Authorization") String authorization) throws JsonProcessingException {
+        AppUser user = authController.getUser(authorization);
+        String userId = String.valueOf(user.getId());
+        Schedule newSched = new Schedule(null, name, description, quarter, userId);
+        Schedule savedSched= scheduleRepository.save(newSched);
+        return ResponseEntity.ok().body(mapper.writeValueAsString(savedSched));
+    }
+
+    @PutMapping(value = "/updateSchedule", produces = "application/json")
+    public ResponseEntity<String> updateSchedule(@RequestParam String id,
+                                                 @RequestParam String name,
+                                                 @RequestParam String description,
+                                                 @RequestParam String quarter,
+                                                 @RequestHeader("Authorization") String authorization) throws JsonProcessingException {
+        AppUser user = authController.getUser(authorization);
+        String userId = String.valueOf(user.getId());
+        Long castId = Long.parseLong(id);
+        Optional<Schedule> schedule = scheduleRepository.findById(castId);
+        if (!schedule.isPresent()) {
+          return ResponseEntity.notFound().build();
+        }
+        if (!castId.equals(schedule.get().getId()) || !schedule.get().getUserId().equals(userId)) {
+          return ResponseEntity.badRequest().build();
+        }
+
+        schedule.get().setName(name);
+        schedule.get().setDescription(description);
+        schedule.get().setQuarter(quarter);
+        scheduleRepository.save(schedule.get());
+        String body = mapper.writeValueAsString(schedule.get());
+        return ResponseEntity.ok().body(body);
+      }
+
+    @DeleteMapping(value = "/deleteSchedule", produces = "application/json")
+    public ResponseEntity<String> deleteSchedule(@RequestHeader("Authorization") String authorization, @RequestParam String id){
+        AppUser user = authController.getUser(authorization);
+        String userId = String.valueOf(user.getId());
+        Long castId = Long.parseLong(id);
+        Optional<Schedule> target = scheduleRepository.findById(castId);
+        if (!target.isPresent() || !target.get().getUserId().equals(userId)) {
+            return ResponseEntity.notFound().build();
+        }
+        scheduleRepository.deleteById(castId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping(value = "/getSchedule", produces = "application/json")
+    public ResponseEntity<String> getSchedule(@RequestHeader("Authorization") String authorization, @RequestParam String id) 
+        throws JsonProcessingException{
+        AppUser user = authController.getUser(authorization);
+        String userId = String.valueOf(user.getId());
+        Long castId = Long.parseLong(id);
+        Optional<Schedule> target = scheduleRepository.findById(castId);
+        if (target.isPresent() && target.get().getUserId().equals(userId)) {
+          String body = target.get().toString();
+          return ResponseEntity.ok().body(mapper.writeValueAsString(target.get()));
+        }
+        return ResponseEntity.badRequest().build();
+    }
+
+    @GetMapping(value = "/getSchedules", produces = "application/json")
+      public ResponseEntity<String> getSchedules(@RequestHeader("Authorization") String authorization) 
+          throws JsonProcessingException{
+          AppUser user = authController.getUser(authorization);
+          String userId = String.valueOf(user.getId());
+          List<Schedule> savedSchedules= scheduleRepository.findByUserId(userId);
+          String res = "[";
+          for (Schedule sched: savedSchedules){
+            res = res.concat(mapper.writeValueAsString(sched) + ",");
+          }
+          if (res.length() == 1) {
+            return ResponseEntity.noContent().build();
+          }
+          return ResponseEntity.ok().body(res.substring(0,res.length()-1)+"]");
+     }
+}

--- a/src/main/java/edu/ucsb/courses/entities/Schedule.java
+++ b/src/main/java/edu/ucsb/courses/entities/Schedule.java
@@ -1,0 +1,100 @@
+package edu.ucsb.courses.entities;
+
+import java.util.Objects;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+
+@Entity
+public class Schedule {
+  @Id
+  @GeneratedValue(strategy = GenerationType.AUTO)
+  private Long id;
+  @Column(nullable = true)
+  private String name;
+  @Column(nullable = false)
+  private String quarter;
+  @Column(nullable = false)
+  private String userId;
+  @Column(nullable = true)
+  private String description;
+
+  public Schedule(Long id, String name, String description, String quarter, String userId) {
+    this.id = id;
+    this.name = name;
+    this.description = description;
+    this.quarter = quarter;
+    this.userId = userId;
+  }
+
+  public Schedule(){
+  }
+
+  public Long getId() {
+    return this.id;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return this.name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public void setDescription(String description){
+    this.description = description;
+  }
+  public String getDescription(){
+    return this.description;
+  }
+
+  public String getQuarter() {
+    return this.quarter;
+  }
+
+  public void setQuarter(String quarter) {
+    this.quarter = quarter;
+  }
+
+  public String getUserId() {
+    return this.userId;
+  }
+
+  public void setUserId(String userId) {
+    this.userId = userId;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == this)
+      return true;
+    if (!(o instanceof Schedule)) {
+      return false;
+    }
+    Schedule schedule = (Schedule) o;
+    EqualsBuilder builder = new EqualsBuilder();
+    builder.append(id, schedule.getId()).append(name, schedule.getName()).append(description, schedule.description).append(quarter, schedule.getQuarter())
+        .append(userId, schedule.getUserId());
+    return builder.build();
+  }
+
+  @Override
+    public int hashCode() {
+        return Objects.hash(id, name, description, quarter, userId);
+    }
+
+  @Override
+  public String toString() {
+    return String.format("Schedule[ id=%d, name=%s, description=%s, quarter=%s, userId=%s ]", id, name, description, quarter, userId);
+  }
+
+}

--- a/src/main/java/edu/ucsb/courses/repositories/ScheduleRepository.java
+++ b/src/main/java/edu/ucsb/courses/repositories/ScheduleRepository.java
@@ -1,0 +1,16 @@
+package edu.ucsb.courses.repositories;
+
+import java.util.List;
+
+import edu.ucsb.courses.entities.Schedule;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+import java.util.Optional;
+
+
+@Repository
+public interface ScheduleRepository extends CrudRepository<Schedule, Long> {
+  List<Schedule> findAll();
+  List<Schedule> findByUserId(String userId);
+}

--- a/src/test/java/edu/ucsb/courses/controllers/ScheduleControllerTests.java
+++ b/src/test/java/edu/ucsb/courses/controllers/ScheduleControllerTests.java
@@ -1,0 +1,334 @@
+package edu.ucsb.courses.controllers;
+
+
+import edu.ucsb.courses.advice.AuthControllerAdvice;
+import edu.ucsb.courses.entities.AppUser;
+import netscape.javascript.JSObject;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.ucsb.courses.repositories.ScheduleRepository;
+import edu.ucsb.courses.entities.Schedule;
+
+@WebMvcTest(value = ScheduleController.class)
+@WithMockUser
+public class ScheduleControllerTests {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @MockBean
+  ScheduleRepository mockScheduleRepository;
+
+  @MockBean
+  AuthControllerAdvice authController;
+
+  private String userToken() {
+    return "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTYiLCJuYW1lIjoiSm9obiBEb2UiLCJpYXQiOjE1MTYyMzkwMjJ9.MkiS50WhvOFwrwxQzd5Kp3VzkQUZhvex3kQv-CLeS3M";
+  }
+
+  @Test
+    public void testUpdateSchedule_scheduleExists_updateValues() throws Exception {
+      Schedule inputSchedule = new Schedule(1L,"CS 156", "New", "Fall 2020", "123456");
+      Schedule savedSchedule = new Schedule(1L,"CS 156", "Old", "Fall 2020", "123456");
+      String body = objectMapper.writeValueAsString(inputSchedule);
+      AppUser user = new AppUser();
+      user.setId(123456L);
+      when(authController.getUser(any(String.class))).thenReturn(user);
+
+      when(mockScheduleRepository.findById(any(Long.class))).thenReturn(Optional.of(savedSchedule));
+      when(mockScheduleRepository.save(inputSchedule)).thenReturn(inputSchedule);
+      MvcResult response =
+          mockMvc
+              .perform(put("/api/public/updateSchedule?id=1&name=CS 156&description=New&quarter=Fall 2020&userId=123456").with(csrf()).contentType(MediaType.APPLICATION_JSON)
+                  .characterEncoding("utf-8")
+                  .header(HttpHeaders.AUTHORIZATION, "Bearer " + userToken()).content(body))
+              .andExpect(status().isOk()).andReturn();
+
+      verify(mockScheduleRepository, times(1)).findById(inputSchedule.getId());
+      verify(mockScheduleRepository, times(1)).save(inputSchedule);
+
+      String responseString = response.getResponse().getContentAsString();
+
+      assertEquals(body, responseString);
+    }
+
+  @Test
+    public void testUpdateSchedule_ScheduleNotFound() throws Exception {
+      Schedule inputSchedule = new Schedule(1L,"CS 156", "New", "Fall 2020", "123456");
+      String body = objectMapper.writeValueAsString(inputSchedule);
+      AppUser user = new AppUser();
+      user.setId(123456L);
+      when(authController.getUser(any(String.class))).thenReturn(user);
+
+      when(mockScheduleRepository.findById(1L)).thenReturn(Optional.empty());
+      mockMvc.perform(put("/api/public/updateSchedule?id=1&name=CS 156&description=New&quarter=Fall 2020&userId=123456").with(csrf()).contentType(MediaType.APPLICATION_JSON)
+          .characterEncoding("utf-8").header(HttpHeaders.AUTHORIZATION, "Bearer " + userToken())
+          .content(body)).andExpect(status().isNotFound()).andReturn();
+      verify(mockScheduleRepository, times(1)).findById(1L);
+      verify(mockScheduleRepository, times(0)).save(any(Schedule.class));
+    }
+
+  @Test
+  public void testUpdateSchedule_ScheduleNotMatch() throws Exception {
+    Schedule inputSchedule = new Schedule(1L,"CS 156", "New", "Fall 2020", "123456");
+    String body = objectMapper.writeValueAsString(inputSchedule);
+    AppUser user = new AppUser();
+    user.setId(123456L);
+    when(authController.getUser(any(String.class))).thenReturn(user);
+    Schedule savedSchedule = new Schedule(2L,"CS 156", "Old", "Fall 2020", "NOT YOURS");
+    when(mockScheduleRepository.findById(any(Long.class))).thenReturn(Optional.of(savedSchedule));
+    when(mockScheduleRepository.findById(1L)).thenReturn(Optional.of(savedSchedule));
+    mockMvc.perform(put("/api/public/updateSchedule?id=1&name=CS 156&description=New&quarter=Fall 2020&userId=123456").with(csrf()).contentType(MediaType.APPLICATION_JSON)
+            .characterEncoding("utf-8").header(HttpHeaders.AUTHORIZATION, "Bearer " + userToken())
+            .content(body)).andExpect(status().isBadRequest()).andReturn();
+    verify(mockScheduleRepository, times(1)).findById(1L);
+    verify(mockScheduleRepository, times(0)).save(any(Schedule.class));
+  }
+
+  @Test
+  public void testUpdateTodo_todoAtPathOwned_butTryingToInjectTodoForAnotherUser()
+      throws Exception {
+    Schedule inputSchedule = new Schedule(1L,"CS 156", "New trying to inject at user id 654321", "Fall 2020", "123456");
+    Schedule savedSchedule = new Schedule(1L,"CS 156", "Old", "Fall 2020", "NOT YOURS");
+    String body = objectMapper.writeValueAsString(inputSchedule);
+    when(mockScheduleRepository.findById(any(Long.class))).thenReturn(Optional.of(savedSchedule));
+    AppUser user = new AppUser();
+    user.setId(123456L);
+    when(authController.getUser(any(String.class))).thenReturn(user);
+    mockMvc.perform(put("/api/public/updateSchedule?id=1&name=CS 156&description=New trying to inject from user id 123456&quarter=Fall 2020").with(csrf()).contentType(MediaType.APPLICATION_JSON)
+        .characterEncoding("utf-8").header(HttpHeaders.AUTHORIZATION, "Bearer " + userToken())
+        .content(body)).andExpect(status().isBadRequest()).andReturn();
+    verify(mockScheduleRepository, times(1)).findById(1L);
+    verify(mockScheduleRepository, times(0)).save(any(Schedule.class));
+  }
+
+  @Test
+  public void testGetSchedule() throws Exception {
+    Schedule s1 = new Schedule(1L,"CS 156", "Adv App Programming", "Fall 2020", "123456");
+    Optional<Schedule> expectedSchedules = Optional.of(s1);
+
+    when(mockScheduleRepository.findById(1L)).thenReturn(expectedSchedules);
+    AppUser user = new AppUser();
+    user.setId(123456L);
+    when(authController.getUser(any(String.class))).thenReturn(user);
+    MvcResult response =
+        mockMvc
+            .perform(get("/api/public/getSchedule?id=1").contentType("application/json")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + userToken()))
+            .andExpect(status().isOk()).andReturn();
+
+    verify(mockScheduleRepository, times(1)).findById(1L);
+
+    String responseString = response.getResponse().getContentAsString();
+    Schedule returnVal = objectMapper.readValue(responseString, Schedule.class);
+    assertEquals(returnVal, s1);
+  }
+
+  @Test
+  public void testGetScheduleNotExist() throws Exception {
+    Optional<Schedule> expectedSchedules = Optional.empty();
+    String expectedResult = "";
+    when(mockScheduleRepository.findById(any(Long.class))).thenReturn(expectedSchedules);
+    AppUser user = new AppUser();
+    user.setId(123456L);
+    when(authController.getUser(any(String.class))).thenReturn(user);
+    MvcResult response =
+        mockMvc
+            .perform(get("/api/public/getSchedule?id=1").contentType("application/json")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + userToken()))
+            .andExpect(status().isBadRequest()).andReturn();
+
+    verify(mockScheduleRepository, times(1)).findById(1L);
+
+    String responseString = response.getResponse().getContentAsString();
+    
+    assertEquals(expectedResult, responseString);
+  }
+
+  @Test
+  public void testGetScheduleNoAuth() throws Exception {
+    Schedule s1 = new Schedule(1L,"CS 156", "Adv App Programming", "Fall 2020", "NOT YOURS");
+    Optional<Schedule> expectedSchedules = Optional.of(s1);
+    String expectedResult = "";
+    when(mockScheduleRepository.findById(any(Long.class))).thenReturn(expectedSchedules);
+    AppUser user = new AppUser();
+    user.setId(123456L);
+    when(authController.getUser(any(String.class))).thenReturn(user);
+    MvcResult response =
+        mockMvc
+            .perform(get("/api/public/getSchedule?id=1").contentType("application/json")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + userToken()))
+            .andExpect(status().isBadRequest()).andReturn();
+
+    verify(mockScheduleRepository, times(1)).findById(1L);
+
+    String responseString = response.getResponse().getContentAsString();
+    
+    assertEquals(expectedResult, responseString);
+  }
+
+  @Test
+    public void testGetSchedules() throws Exception {
+      Schedule s1 = new Schedule(1L,"CS 156", "Adv App Programming", "Fall 2020", "123456");
+      Schedule s2 = new Schedule(2L,"CS 156", "Adv App Programming", "Fall 2020", "123456");
+      List<Schedule> schedules = new ArrayList<Schedule>();
+      schedules.add(s1);
+      schedules.add(s2);
+
+      when(mockScheduleRepository.findByUserId("123456")).thenReturn(schedules);
+      AppUser user = new AppUser();
+      user.setId(123456L);
+      when(authController.getUser(any(String.class))).thenReturn(user);
+      MvcResult response =
+          mockMvc
+              .perform(get("/api/public/getSchedules").contentType("application/json")
+                  .header(HttpHeaders.AUTHORIZATION, "Bearer " + userToken()))
+              .andExpect(status().isOk()).andReturn();
+
+      verify(mockScheduleRepository, times(1)).findByUserId("123456");
+
+      String responseString = response.getResponse().getContentAsString();
+      List<Schedule> responses = objectMapper.readValue(responseString, new TypeReference<List<Schedule>>(){});
+
+      assertEquals(s1, responses.get(0));
+      assertEquals(s2,responses.get(1));
+    }
+
+  @Test
+    public void testGetSchedulesNoContent() throws Exception {
+      List<Schedule> schedules = new ArrayList<Schedule>();
+      String expectedResult = "";
+      when(mockScheduleRepository.findByUserId("123456")).thenReturn(schedules);
+      AppUser user = new AppUser();
+      user.setId(123456L);
+      when(authController.getUser(any(String.class))).thenReturn(user);
+      MvcResult response =
+          mockMvc
+              .perform(get("/api/public/getSchedules").contentType("application/json")
+                  .header(HttpHeaders.AUTHORIZATION, "Bearer " + userToken()))
+              .andExpect(status().isNoContent()).andReturn();
+
+      verify(mockScheduleRepository, times(1)).findByUserId("123456");
+
+      String responseString = response.getResponse().getContentAsString();
+
+      assertEquals(responseString, expectedResult);
+    }
+
+  @Test
+    public void testCreateSchedule() throws Exception {
+      Schedule s1 = new Schedule(1L,"CS 156", "Adv App Programming", "Fall 2020", "123456");
+      when(mockScheduleRepository.save(any(Schedule.class))).thenReturn(s1);
+      AppUser user = new AppUser();
+      user.setId(123456L);
+      when(authController.getUser(any(String.class))).thenReturn(user);
+      MvcResult response = mockMvc
+          .perform(post("/api/public/createSchedule?name=CS 156&description=Adv App Programming&quarter=Fall 2020&userId=123456").with(csrf()).contentType(MediaType.APPLICATION_JSON)
+              .header(HttpHeaders.AUTHORIZATION, "Bearer " + userToken()))
+          .andExpect(status().isOk()).andReturn();
+
+
+      String responseString = response.getResponse().getContentAsString();
+      //String expectedString = "Schedule[ id=1, name=CS 156, description=Adv App Programming, quarter=Fall 2020, userId=123456 ]";
+      Schedule returnVal = objectMapper.readValue(responseString, Schedule.class);
+      assertEquals(returnVal, s1);
+    }
+
+  @Test
+    public void testGetScheduleFailure() throws Exception {
+      Optional<Schedule> expectedSchedules = Optional.empty();
+
+      when(mockScheduleRepository.findById(1L)).thenReturn(expectedSchedules);
+      AppUser user = new AppUser();
+      user.setId(123456L);
+      when(authController.getUser(any(String.class))).thenReturn(user);
+
+      MvcResult response =
+          mockMvc
+              .perform(get("/api/public/getSchedule?id=1").contentType("application/json")
+                  .header(HttpHeaders.AUTHORIZATION, "Bearer " + userToken()))
+              .andExpect(status().isBadRequest()).andReturn();
+
+      verify(mockScheduleRepository, times(1)).findById(1L);
+
+      String responseString = response.getResponse().getContentAsString();
+      String actualString = "";
+      assertEquals(actualString, responseString);
+    }
+
+@Test
+    public void testDeleteSchedule_scheduleExists() throws Exception {
+      Schedule s1 = new Schedule(1L,"CS 156", "Adv App Programming", "Fall 2020", "123456");
+      when(mockScheduleRepository.findById(1L)).thenReturn(Optional.of(s1));
+      AppUser user = new AppUser();
+      user.setId(123456L);
+      when(authController.getUser(any(String.class))).thenReturn(user);
+      MvcResult response = mockMvc
+          .perform(delete("/api/public/deleteSchedule?id=1").with(csrf()).contentType(MediaType.APPLICATION_JSON)
+              .characterEncoding("utf-8").header(HttpHeaders.AUTHORIZATION, "Bearer " + userToken()))
+          .andExpect(status().isNoContent()).andReturn();
+      verify(mockScheduleRepository, times(1)).findById(s1.getId());
+      verify(mockScheduleRepository, times(1)).deleteById(s1.getId());
+
+      String responseString = response.getResponse().getContentAsString();
+
+      assertEquals(responseString.length(), 0);
+    }
+  
+@Test
+  public void testDeleteSchedule_scheduleNotFound() throws Exception {
+    long id = 1L;
+    when(mockScheduleRepository.findById(id)).thenReturn(Optional.empty());
+    AppUser user = new AppUser();
+    user.setId(123456L);
+    when(authController.getUser(any(String.class))).thenReturn(user);
+    mockMvc
+        .perform(delete("/api/public/deleteSchedule?id=1").with(csrf()).contentType(MediaType.APPLICATION_JSON)
+            .characterEncoding("utf-8").header(HttpHeaders.AUTHORIZATION, "Bearer " + userToken()))
+        .andExpect(status().isNotFound()).andReturn();
+    verify(mockScheduleRepository, times(1)).findById(id);
+    verify(mockScheduleRepository, times(0)).deleteById(id);
+  }
+
+@Test
+  public void testDeleteTodo_NotOwned() throws Exception {
+    Schedule s1 = new Schedule(1L,"CS 156", "Adv App Programming", "Fall 2020", "NOT YOURS");
+    when(mockScheduleRepository.findById(s1.getId())).thenReturn(Optional.of(s1));
+    AppUser user = new AppUser();
+    user.setId(123456L);
+    when(authController.getUser(any(String.class))).thenReturn(user);
+    mockMvc
+        .perform(delete("/api/public/deleteSchedule?id=1").with(csrf()).contentType(MediaType.APPLICATION_JSON)
+            .characterEncoding("utf-8").header(HttpHeaders.AUTHORIZATION, "Bearer " + userToken()))
+        .andExpect(status().isNotFound()).andReturn();
+    verify(mockScheduleRepository, times(1)).findById(s1.getId());
+    verify(mockScheduleRepository, times(0)).deleteById(s1.getId());
+  }
+}

--- a/src/test/java/edu/ucsb/courses/entities/ScheduleTests.java
+++ b/src/test/java/edu/ucsb/courses/entities/ScheduleTests.java
@@ -1,0 +1,69 @@
+package edu.ucsb.courses.entities;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import org.junit.jupiter.api.Test;
+
+public class ScheduleTests {
+  @Test
+  public void testSchedule_notEqualNull() throws Exception {
+    long id = Long.parseLong("1");
+    Schedule schedule = new Schedule(id,"","","F20","1");
+    assertNotEquals(schedule, null);
+  }
+
+  @Test
+  public void testSchedule_gettersAndSetters() throws Exception {
+    long id = Long.parseLong("1");
+    Schedule schedule = new Schedule(id,"","","F20","1");
+    assertEquals(schedule.getId(),id);
+    assertEquals(schedule.getName(),"");
+    assertEquals(schedule.getDescription(),"");
+    assertEquals(schedule.getQuarter(), "F20");
+    assertEquals(schedule.getUserId(), "1");
+
+    id = Long.parseLong("2");
+    schedule.setId(id);
+    schedule.setName("Test schedule");
+    schedule.setDescription("Favorite");
+    schedule.setQuarter("W21");
+    schedule.setUserId("2");
+    assertEquals(schedule.getId(),id);
+    assertEquals(schedule.getName(),"Test schedule");
+    assertEquals(schedule.getDescription(),"Favorite");
+    assertEquals(schedule.getQuarter(), "W21");
+    assertEquals(schedule.getUserId(), "2");
+  }
+
+  @Test
+  public void testSchedule_notEqualAnotherSchedule() throws Exception {
+    long id = Long.parseLong("1");
+    Schedule schedule = new Schedule(id,"","","F20","1");
+    long id2 = Long.parseLong("2");
+    Schedule schedule2 = new Schedule(id2,"","","F20","1");
+    assertNotEquals(schedule, new Object());
+    assertNotEquals(schedule, schedule2);
+  }
+
+  @Test
+  public void testSchedule_equalsSelf() throws Exception {
+    long id = Long.parseLong("1");
+    Schedule schedule = new Schedule(id,"","","F20","1");
+    assertEquals(schedule, schedule);
+  }
+
+  @Test
+  public void testSchedule_toString() throws Exception {
+    long id = Long.parseLong("1");
+    Schedule schedule = new Schedule(id,"","","F20","1");
+    assertEquals(schedule.toString(), "Schedule[ id=1, name=, description=, quarter=F20, userId=1 ]");
+  }
+
+  @Test
+  public void testSchedule_hashCode(){
+    long id = Long.parseLong("1");
+    Schedule s1 = new Schedule(id,"Test","A test schedule.","F20","1");
+    Schedule s2 = new Schedule(id,"Test","A test schedule.","F20","1");
+    assertEquals(s1.hashCode(),s2.hashCode());
+  }
+}


### PR DESCRIPTION
This pull request closes issues #50 and #35. This branch adds a schedule table to the back end alongside a controller that allows crud operations to be performed on schedule entities. It also includes testing for the schedule entity and schedule controller. 